### PR TITLE
google me script

### DIFF
--- a/src/scripts/google.coffee
+++ b/src/scripts/google.coffee
@@ -11,5 +11,5 @@ googleMe = (msg, query, cb) ->
   msg.http('http://www.google.com/search')
     .query(q: query)
     .get() (err, res, body) ->
-      cb body.match(/<a href="([^"]*)" class=l>/)[1]
+      cb body.match(/<a href="([^"]*)" class=l>/)?[1] || "Sorry, Google had zero results for '#{query}'"
 


### PR DESCRIPTION
Didn't see something like this in the existing scripts, so I just wrote this one up quickly.

Just type `google me <query>` and it'll [parse the HTML with regex](http://www.codinghorror.com/blog/2009/11/parsing-html-the-cthulhu-way.html) to return you the URL of the first hit (like "I'm Feelin' Lucky").
