### PR TITLE
Added a sudo script (fun)

### DIFF
--- a/src/scripts/sudo.coffee
+++ b/src/scripts/sudo.coffee
@@ -2,6 +2,6 @@
 #
 # hubot sudo <anything you want> - Force hubot to do what you want
 module.exports = (robot) ->
-  robot.respond /(sudo) (.*)/i, (msg) ->
-    msg.send "Alright. I'll #{msg.match[2]}"
+  robot.respond /(sudo)(.*)/i, (msg) ->
+    msg.send "Alright. I'll #{msg.match?[2] || "do whatever it is you wanted."}"
 


### PR DESCRIPTION
Saw someone try this:

```
hubot make me a sandwich
```

To which, hubot did not respond. So then the author sent:

```
hubot sudo make me a sandwich
```

To which hubot still did not respond. There was much sadness.

This pull request rectifies that. With the sudo.coffee script, he'll instead have seen:

```
hubot sudo make me a sandwich

Alright. I'll make me a sandwich
```
