### PR TITLE
Adjusted tweet command parameters and added a guard for queries that don't return results

### DIFF
--- a/src/scripts/tweet.coffee
+++ b/src/scripts/tweet.coffee
@@ -1,6 +1,6 @@
 # Display a random tweet from twitter about a subject
 #
-# tweet me <query> - Returns a random link to a tweet about <query>
+# <robot_name> tweet me <query> - Returns a random link to a tweet about <query>
 
 module.exports = (robot) ->
   robot.respond /(tweet)( me)? (.*)/i, (msg) ->


### PR DESCRIPTION
Certain queries were throwing errors when robot.random was attempting to call .length() on undefined.
