### PR TITLE
Remove 'hubot' reference from tomdocs?

### DIFF
--- a/src/scripts/haters.coffee
+++ b/src/scripts/haters.coffee
@@ -1,6 +1,6 @@
 # Display a random "haters gonna hate" image
 #
-# hubot haters - Returns a random haters gonna hate url
+# haters - Returns a random haters gonna hate url
 #
 #
 haters = [

--- a/src/scripts/rubygems.coffee
+++ b/src/scripts/rubygems.coffee
@@ -1,6 +1,6 @@
 # Find a rubygem from rubygems.org
 #
-# hubot <there's a gem for> that - Returns a link to a gem on rubygems.org
+# <there's a gem for> that - Returns a link to a gem on rubygems.org
 #
 
 module.exports = (robot) ->

--- a/src/scripts/travis.coffee
+++ b/src/scripts/travis.coffee
@@ -1,6 +1,6 @@
 # Find the build status of an open-source project on Travis
 #
-# hubot <travis me> sferik/rails_admin - Returns the build status of https://github.com/sferik/rails_admin
+# <travis me> sferik/rails_admin - Returns the build status of https://github.com/sferik/rails_admin
 #
 
 module.exports = (robot) ->

--- a/src/scripts/tweet.coffee
+++ b/src/scripts/tweet.coffee
@@ -1,6 +1,6 @@
 # Display a random tweet from twitter about a subject
 #
-# hubot <keyword> tweet - Returns a link to a tweet about <keyword>
+# <keyword> tweet - Returns a link to a tweet about <keyword>
 #
 
 module.exports = (robot) ->


### PR DESCRIPTION
Seeing 'hubot' in the help output when Hubot has been renamed seems like it could be misleading?  (And many of the scripts already omit it anyway...)
