### PR TITLE
Spotify script

### DIFF
--- a/src/scripts/spotify.coffee
+++ b/src/scripts/spotify.coffee
@@ -1,0 +1,30 @@
+# Metadata lookup for spotify links
+#
+# <spotify link> - returns info about the link (track, artist, etc.)
+#
+
+module.exports = (robot) ->
+  robot.hear spotify.link, (msg) ->
+    msg.http(spotify.uri msg.match[0]).get() (err, res, body) ->
+      if res.statusCode is 200
+        data = JSON.parse(body)
+        msg.send spotify[data.info.type](data)
+
+spotify =
+  link: /// (
+    ?: http://open.spotify.com/(track|album|artist)/
+     | spotify:(track|album|artist):
+    ) \S+ ///
+
+  uri: (link) -> "http://ws.spotify.com/lookup/1/.json?uri=#{link}"
+
+  track: (data) ->
+    track = "#{data.track.artists[0].name} - #{data.track.name}"
+    album = "(#{data.track.album.name}) (#{data.track.album.released})"
+    "Track: #{track} #{album}"
+
+  album: (data) ->
+    "Album: #{data.album.artist} - #{data.album.name} (#{data.album.released})"
+
+  artist: (data) ->
+    "Artist: #{data.artist.name}"


### PR DESCRIPTION
Automatically looks up metadata for [Spotify](http://www.spotify.com/us/) links using their [metadata API](http://developer.spotify.com/en/metadata-api/overview/)

**Examples**

_Track_

`spotify:track:05lBuZWQ2OhQuzoCSIkvUF` or `http://open.spotify.com/track/05lBuZWQ2OhQuzoCSIkvUF`
->
`Track: Bon Iver - Holocene (Bon Iver) (2011)`

_Album_

`spotify:album:7pTARJYCVO49nFXB1Mo5re`
->
`Album: Bon Iver - Bon Iver (2011)`

_Artist_

`http://open.spotify.com/artist/4LEiUm1SRbFMgfqnQTwUbQ`
->
`Artist: Bon Iver`
