### PR TITLE
Bump wolfram version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "redis": "0.6.7",
     "jsdom": "==0.2.0",
     "xml2js": "0.1.x",
-    "wolfram": "0.1.0",
+    "wolfram": "0.1.1",
     "soupselect": "0.2.0",
     "htmlparser": "1.7.x"
   },


### PR DESCRIPTION
Updates the wolfram package to support heroku cedar stack.
