### PR TITLE
wolfram node package 0.1.1 - so it can install on heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "redis": "0.6.7",
     "jsdom": "==0.2.0",
     "xml2js": "0.1.x",
-    "wolfram": "0.1.0",
+    "wolfram": "0.1.1",
     "soupselect": "0.2.0",
     "htmlparser": "1.7.x"
   },


### PR DESCRIPTION
wolfram node package just got updated to 0.1.1 so it can install on heroku (node version 0.4.7).
The wolfram 0.1.0 package relies on a more recent version of node which does not install cleanly on heroku

hubot currently fails to deploy on heroku due to the wolfram package failing - 

-----> Heroku receiving push
-----> Node.js app detected
-----> Fetching Node.js binaries
-----> Vendoring node 0.4.7
-----> Installing dependencies with npm 1.0.94
       npm ERR! error installing hubot-scripts@1.1.3 Error: Unsupported
       npm ERR! error installing hubot-scripts@1.1.3     at checkEngine (/tmp/node-npm-4PEU/lib/install.js:493:14)
       npm ERR! error installing hubot-scripts@1.1.3     at Array.0 (/tmp/node-npm-4PEU/node_modules/slide/lib/bind-actor.js:15:8)
       npm ERR! error installing hubot-scripts@1.1.3     at LOOP (/tmp/node-npm-4PEU/node_modules/slide/lib/chain.js:15:13)
       npm ERR! error installing hubot-scripts@1.1.3     at chain (/tmp/node-npm-4PEU/node_modules/slide/lib/chain.js:20:4)
       npm ERR! error installing hubot-scripts@1.1.3     at installOne_ (/tmp/node-npm-4PEU/lib/install.js:471:3)
       npm ERR! error installing hubot-scripts@1.1.3     at installOne (/tmp/node-npm-4PEU/lib/install.js:411:3)
       npm ERR! error installing hubot-scripts@1.1.3     at /tmp/node-npm-4PEU/lib/install.js:347:9
       npm ERR! error installing hubot-scripts@1.1.3     at /tmp/node-npm-4PEU/node_modules/slide/lib/async-map.js:54:35
       npm ERR! error installing hubot-scripts@1.1.3     at Array.forEach (native)
       npm ERR! error installing hubot-scripts@1.1.3     at /tmp/node-npm-4PEU/node_modules/slide/lib/async-map.js:54:11
       npm ERR! error rolling back hubot-scripts@1.1.3 Error: ENOTEMPTY, Directory not empty '/tmp/build_31nlkc90c4xtj/node_modules/hubot-scripts'
       npm ERR! Unsupported
       npm ERR! Not compatible with your version of node/npm: wolfram@0.1.0
       npm ERR! Required: {"node":"~v0.4.11"}
       npm ERR! Actual:   {"npm":"1.0.94","node":"0.4.7"}
