### PR TITLE
Use brain 'loaded' event in remind.coffee

### DIFF
--- a/src/scripts/remind.coffee
+++ b/src/scripts/remind.coffee
@@ -13,7 +13,6 @@ class Reminders
       if @robot.brain.data.reminders
         @cache = @robot.brain.data.reminders
         @queue()
-    loadReminders = =>
 
   add: (reminder) ->
     @cache.push reminder


### PR DESCRIPTION
- Removes hacky setTimeout method
