### PR TITLE
Update Weather script to support "natural language" replies, specify temperature format

### DIFF
--- a/src/scripts/weather.coffee
+++ b/src/scripts/weather.coffee
@@ -11,7 +11,7 @@ module.exports = (robot) ->
       return msg.send err if err
 
       city = body.getElementsByTagName("city")[0]
-      return msg.send "Sorry, but you didn't specify a location." if not city or not city.getAttribute
+      return msg.send "Sorry, but I couldn't find that location." if not city or not city.getAttribute
       
       city = city.getAttribute("data")
 


### PR DESCRIPTION
The Weather script now uses a more "natural" format for it's replies. You can now interact with Hubot for weather like this for current conditions:

```
Me: weather in Seattle
Hubot: Currently in Seattle, WA it is Partly Cloudy and 48ºF with a humidity of 71%.
```

Or like this for forecast:

```
Me: forecast for Seattle
Hubot: The forecast for Seattle, WA is as follows:

Tue: Clear with a high of 54ºF and a low of 38ºF.
Wed: Rain with a high of 52ºF and a low of 41ºF.
Thu: Showers with a high of 52ºF and a low of 40ºF.
Fri: Chance of Rain with a high of 49ºF and a low of 41ºF.
```

And if something goes wrong, Hubot will do this:

```
Me: weather
Hubot: Sorry, but I couldn't find that location.
```

Users can now specify what format they would like to receive their weather information in. By default, Hubot will use Fahrenheit format for temperatures. However, by specifying the `HUBOT_WEATHER_CELSIUS` environment variable, Hubot will respond with temperatures in Celsius.
