### PR TITLE
Fetch latest news headlines from Google News

### DIFF
--- a/src/scripts/news.coffee
+++ b/src/scripts/news.coffee
@@ -18,7 +18,7 @@ module.exports = (robot) ->
         strings.push "Here's the latest news headlines:\n"
       
       for story in response.responseData.results
-        strings.push story.titleNoFormatting.replace("&#39;", "'").replace("&quot;", "\"")
+        strings.push story.titleNoFormatting.replace("&#39;", "'").replace("`", "'").replace("&quot;", "\"")
         strings.push story.unescapedUrl + "\n"
 
       msg.send strings.join "\n"


### PR DESCRIPTION
Hubot can now retrieve the latest news headlines from Google News. You can specify specific keywords to look for or just get today's headlines. Take a look at the examples for more information.

Fetch the latest news headlines:

```
Me: Hubot news
Hubot: Here's the latest news headlines:

Greek PM on brink as anxious world watches euro zone
http://www.reuters.com/article/2011/11/03/us-g-idUSTRE7A20E920111103

Occupy Oakland protesters remove barricade at port entrance
http://www.mercurynews.com/occupy-oakland/ci_19255290

Cain camp points to Perry for harassment leak
http://today.msnbc.msn.com/id/45138165/ns/today-today_news/t/cain-camp-points-perry-harassment-leak/

Solyndra's Refinancing Would Have Given U.S. a 40% Stake
http://www.sfgate.com/cgi-bin/article.cgi?f=/g/a/2011/11/03/bloomberg_articlesLU3BAF6JTSEG.DTL

At Least 10 Killed in Syria Despite Peace Plan
http://www.voanews.com/english/news/middle-east/3-Killed-in-Syria-Despite-Peace-Accord-133140793.html
```

You can specify what type of news you are looking for like this:

```
Me: Hubot news on wall street
Hubot: Here's the latest news on "wall street":

Occupy Wall Street: No Whining!
http://www.forbes.com/sites/toddhixon/2011/11/03/occupy-wall-street-no-whining/

Sustainability=Survival at 'Occupy' Protest
http://www.bloomberg.com/news/2011-11-03/sustainability-survival-at-occupy-protest.html

How Occupy Oakland is Stealing Occupy Wall Street's Mojo
http://www.time.com/time/nation/article/0,8599,2098628,00.html

Bernanke chides Occupy Wall Street 'misconceptions'
http://money.cnn.com/2011/11/02/news/economy/bernanke_occupy_wall_street/

Wall Street Is Shrinking
http://powerwall.msnbc.msn.com/politics/wall-street-is-shrinking-1706390.story
```
