### PR TITLE
Fetch latest news headlines from Google News (bug fix)

### DIFF
--- a/src/scripts/news.coffee
+++ b/src/scripts/news.coffee
@@ -18,7 +18,7 @@ module.exports = (robot) ->
         strings.push "Here's the latest news headlines:\n"
       
       for story in response.responseData.results
-        strings.push story.titleNoFormatting.replace("&#39;", "'").replace("`", "'").replace("&quot;", "\"")
+        strings.push story.titleNoFormatting.replace(/&#39;/g, "'").replace(/`/g, "'").replace(/&quot;/g, "\"")
         strings.push story.unescapedUrl + "\n"
 
       msg.send strings.join "\n"


### PR DESCRIPTION
See pull request #94 for additional information about this script.

There was a problem with the original replace methods being used to replace HTML encoded characters in that only the first instance of the character would be replaced. The search is now global and is working properly.

Apologies for pulling the trigger on this (#94) a bit too soon!
