### PR TITLE
Add store messages to CouchDB (via cradle)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "wwwdude": "0.1.0",
     "pypi": "0.1.0",
     "underscore": ">= 1.2.1",
-    "underscore.string": ">= 1.1.6"
+    "underscore.string": ">= 1.1.6",
+    "cradle": "0.5.7"
   },
 
   "directories":  {

--- a/src/scripts/store-messages-couchdb.coffee
+++ b/src/scripts/store-messages-couchdb.coffee
@@ -1,0 +1,25 @@
+Url    = require "url"
+cradle = require "cradle"
+
+# sets up hooks to persist all messages into couchdb.
+module.exports = (robot) ->
+	info   = Url.parse process.env.HUBOT_COUCHDB_URL || 'http://localhost:5984'
+	if info.auth
+		auth = info.auth.split(":")
+		client = new(cradle.Connection) info.hostname, info.port, auth:
+			username: auth[0]
+			password: auth[1]
+	else
+		client = new(cradle.Connection)(info.hostname, info.port)
+
+	db = client.database(if info.pathname != '/' then info.pathname.slice(1) else "hubot-storage")
+
+	robot.hear /.*$/i, (msg) ->
+		message = msg.message
+		message.date = new Date
+
+		# ignore topic and other messages
+		return if typeof message.user.id == 'undefined'
+
+		db.save message, (err, res) -> 
+			if err then console.error(err)


### PR DESCRIPTION
Store all chat messages to CouchDB via @cloudhead/cradle.
