### PR TITLE
Improvements to isup + tests

### DIFF
--- a/src/scripts/isup.coffee
+++ b/src/scripts/isup.coffee
@@ -14,6 +14,8 @@ isUp = (msg, domain, cb) ->
     .get() (err, res, body) ->
       if body.match("It's just you.")
         cb "#{domain} looks UP from here."
-      else
+      else if body.match("It's not just you!")
         cb "#{domain} looks DOWN from here."
+      else
+        cb "Not sure, #{domain} returned an error."
 

--- a/test/scripts/isup_test.coffee
+++ b/test/scripts/isup_test.coffee
@@ -1,0 +1,31 @@
+Tests  = require('../tests')
+assert = require 'assert'
+helper = Tests.helper()
+
+require('../../src/scripts/isup') helper
+
+# start up a danger room for hubot
+danger = Tests.danger helper, (req, res, url) ->
+  if url.pathname == "/fivehundrederror.com"
+    res.writeHead 500
+    res.end "Zomg!"
+  else
+    res.writeHead 200
+    if url.pathname == "/alwaysup.com"
+      res.end "It's just you."
+    else
+      res.end "It's not just you!"
+
+# callbacks for when hubot sends messages
+tests = [
+  (msg) -> assert.equal "alwaysup.com looks UP from here.", msg,
+  (msg) -> assert.equal "alwaysdown.com looks DOWN from here.", msg
+  (msg) -> assert.equal "Not sure, fivehundrederror.com returned an error.", msg
+]
+
+# run the async tests
+danger.start tests, ->
+  helper.receive 'helper: is alwaysup.com up'
+  helper.receive 'helper: is alwaysdown.com down'
+  helper.receive 'helper: is fivehundrederror.com up?'
+


### PR DESCRIPTION
Added tests for isup script.

Also identified a third case (invalid domain) and now handle that too, as well as server error.

```
Hubot: is 500 up?
Not sure, 500 returned an error.
```
