### PR TITLE
Default to the user's email address, if present, for achievements

### DIFF
--- a/src/scripts/achievement_unlocked.coffee
+++ b/src/scripts/achievement_unlocked.coffee
@@ -4,7 +4,7 @@
 module.exports = (robot) ->
   robot.hear /achievement (get|unlock(ed)?) (.+?)(\s*[^@\s]+@[^@\s]+)?\s*$/i, (msg) ->
     caption = msg.match[3]
-    email = msg.match[4]
+    email = msg.match[4] || msg.message.user.email_address
     url = "http://achievement-unlocked.heroku.com/xbox/#{escape(caption)}.png"
     if email
       url += "?email=#{escape(email.trim())}.png"


### PR DESCRIPTION
If hubot knows the user's email address, might as well use that for unlocked achievements. No down-side, as an "invalid" email address, with no gravatar, is simply ignored by the API.
