### PR TITLE
Allow branch names with dashes and numbers in.

### DIFF
--- a/src/scripts/jenkins.coffee
+++ b/src/scripts/jenkins.coffee
@@ -11,7 +11,7 @@
 # build branch master -- starts a build for branch origin/master
 # build branch master on job Foo -- starts a build for branch origin/master on job Foo
 module.exports = (robot) ->
-  robot.respond /build\s*(branch\s+)?(\w+\/?\w+)(\s+(on job)?\s*(\w+))?/i, (msg)->
+  robot.respond /build\s*(branch\s+)?([\w\d\-\/]+)(\s+(on job)?\s*(\w+))?/i, (msg)->
 
     url = process.env.HUBOT_JENKINS_URL
 


### PR DESCRIPTION
The current regex component fails to correctly match branch names with dashes or numbers in, this fix helps for that. I'm not sure it covers all possible cases, but I feel it is a step in the right direction.
