### PR TITLE
Make meme_generator return the full image url. 

### DIFF
--- a/src/scripts/meme_generator.coffee
+++ b/src/scripts/meme_generator.coffee
@@ -76,6 +76,6 @@ memeGenerator = (msg, generatorID, imageID, text0, text1, callback) ->
         img = result['instanceImageUrl']
         msg.http(instanceURL).get() (err, res, body) ->
           # Need to hit instanceURL so that image gets generated
-          callback img
+          callback "http://memegenerator.net#{img}"
       else
         msg.reply "Sorry, I couldn't generate that image."


### PR DESCRIPTION
Looks like memegenerator changed their API a bit.

It only returned '/cache/instances/400x/11/11364/1234*.jpg', now this prepends 'http://memegenerator.net' which seems fine.
