### PR TITLE
Added script that allows hubot to SMS people via the twilio API.

### DIFF
--- a/src/scripts/sms.coffee
+++ b/src/scripts/sms.coffee
@@ -1,0 +1,29 @@
+# Allows Hubot to send text messages using Twilio API.
+#
+# sms <to> <message> - Sends <message> to the number <to>.
+
+QS = require "querystring"
+
+module.exports = (robot) ->
+  robot.respond /sms (\d+) (.*)/i, (msg) ->
+    to    = msg.match[1]
+    bahdy = msg.match[2] # bahdy, that's how john mayer would say it.
+    sid   = process.env.HUBOT_SMS_SID
+    tkn   = process.env.HUBOT_SMS_TOKEN
+    from  = process.env.HUBOT_SMS_FROM
+    auth  = 'Basic ' + new Buffer(sid + ':' + tkn).toString("base64")
+    data  = QS.stringify From: from, To: to, Body: bahdy
+
+    msg.http("https://api.twilio.com")
+      .path("/2010-04-01/Accounts/#{sid}/SMS/Messages.json")
+      .header("Authorization", auth)
+      .header("Content-Type", "application/x-www-form-urlencoded")
+      .post(data) (err, res, body) ->
+        json = JSON.parse body
+        switch res.statusCode
+          when 201
+            msg.send "Sent sms to #{to}"
+          when 400
+            msg.send "Failed to send. #{json.message}"
+          else
+            msg.send "Failed to send."


### PR DESCRIPTION
Allows hubot to send text messages using the twilio API. 

Users must set the three config vars used:
- HUBOT_SMS_SID
- HUBOT_SMS_TOKEN
- HUBOT_SMS_FROM
