### PR TITLE
Add "bang" script for storing text snippets.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "underscore": ">= 1.2.1",
     "underscore.string": ">= 1.1.6",
     "cradle": "0.5.7",
-    "clark": ">= 0.0.3"
+    "clark": ">= 0.0.3",
+    "bang": "0.2.x",
+    "shellwords": "0.0.x"
   },
 
   "directories":  {

--- a/src/scripts/bang.coffee
+++ b/src/scripts/bang.coffee
@@ -1,0 +1,50 @@
+# `hubot bang [--help|--list|--delete] <key> [value]` - Store and retrieve text snippets.
+
+# A Hubot interface for Bang, a key-value store for text snippets
+# http://git.io/bang
+
+# Dependent on "bang" and "shellwords" modules.
+
+Bang  = require "bang"
+{split} = require "shellwords"
+
+module.exports = (robot) ->
+  robot.respond /bang\s+(.*)/i, (msg) ->
+    try
+      args = split(msg.match[1])
+    catch error
+      return msg.send "I couldn't Bang that cause your quotes didn't match."
+
+    bang = new Bang
+    bang.data = robot.brain.data.bang ?= {}
+    bang.save = ->
+
+    [key, value] = args
+
+    if key in ["-h", "--help"]
+      msg.send  """
+                Bang stores text snippets in my brain.
+                Set a key:    #{robot.name} bang foo bar
+                Get a key:    #{robot.name} bang foo
+                Delete a key: #{robot.name} bang [-d|--delete] foo
+                List keys:    #{robot.name} bang [-l|--list]
+                Get help:     #{robot.name} bang [-h|--help]
+                """
+    else if key in ["-l", "--list"]
+      list = bang.list()
+      if list
+        msg.send list
+      else
+        msg.send "I couldn't find any Bang data in my brain."
+    else if key in ["-d", "--delete"] and value
+      bang.delete value
+      msg.send "I stopped Banging #{value}."
+    else if key and value
+      bang.set key, value
+      msg.send "I Banged #{value} into #{key}."
+    else if key
+      result = bang.get key
+      if result
+        msg.send result
+      else
+        msg.send "Nothing's been Banged into #{key}."


### PR DESCRIPTION
Added a Hubot interface for [Bang](https://github.com/jimmycuadra/bang), a simple key-value store for text snippets. Usage, from the help command:

```
Bang stores text snippets in my brain.
Set a key:    hubot bang foo bar
Get a key:    hubot bang foo
Delete a key: hubot bang [-d|--delete] foo
List keys:    hubot bang [-l|--list]
Get help:     hubot bang [-h|--help]
```

This required adding the `bang` and `shellwords` modules to `package.json`. 
