### PR TITLE
Added the ability to set dimensions for the generated memes

### DIFF
--- a/src/scripts/meme_generator.coffee
+++ b/src/scripts/meme_generator.coffee
@@ -49,6 +49,7 @@ module.exports = (robot) ->
 memeGenerator = (msg, generatorID, imageID, text0, text1, callback) ->
   username = process.env.HUBOT_MEMEGEN_USERNAME
   password = process.env.HUBOT_MEMEGEN_PASSWORD
+  preferredDimensions = process.env.HUBOT_MEMEGEN_DIMENSIONS
 
   unless username
     msg.send "MemeGenerator username isn't set. Sign up at http://memegenerator.net"
@@ -71,11 +72,15 @@ memeGenerator = (msg, generatorID, imageID, text0, text1, callback) ->
       text1: text1
     .get() (err, res, body) ->
       result = JSON.parse(body)['result']
-      if result? and result['instanceUrl']? and result['instanceImageUrl']?
+      if result? and result['instanceUrl']? and result['instanceImageUrl']? and result['instanceID']?
+        instanceID = result['instanceID']
         instanceURL = result['instanceUrl']
         img = result['instanceImageUrl']
         msg.http(instanceURL).get() (err, res, body) ->
           # Need to hit instanceURL so that image gets generated
-          callback "http://memegenerator.net#{img}"
+          if preferredDimensions?
+            callback "http://images.memegenerator.net/instances/#{preferredDimensions}/#{instanceID}.jpg"
+          else
+            callback "http://memegenerator.net#{img}"
       else
         msg.reply "Sorry, I couldn't generate that image."


### PR DESCRIPTION
Love the memes but they can take up quite a lot of the screen so I made it possible to specify the size of the image specified in the URL according to the documentation (eg. x200 to limit the height to 200px, 300x to limit to 300px wide, etc).

This is done by setting the HUBOT_MEMEGEN_DIMENSIONS environment variable according to the dimensions you require according to the API documentation. If not set then it uses the size of image specified in the response as currently.
