### PR TITLE
Makes 'me' optional in shorten script

### DIFF
--- a/src/scripts/shorten.coffee
+++ b/src/scripts/shorten.coffee
@@ -3,13 +3,13 @@
 # (bitly|shorten) me <url> - Shorten the URL using bit.ly
 
 module.exports = (robot) ->
-  robot.respond /(bitly|shorten) me (.+)$/, (msg) ->
+  robot.respond /(bitly|shorten) (me)? (.+)$/, (msg) ->
     msg
       .http("http://api.bitly.com/v3/shorten")
       .query
         login: process.env.HUBOT_BITLY_USERNAME
         apiKey: process.env.HUBOT_BITLY_API_KEY
-        longUrl: msg.match[2]
+        longUrl: msg.match[3]
         format: "json"
       .get() (err, res, body) ->
         response = JSON.parse body


### PR DESCRIPTION
'me' should be optional as in most Hubot scripts
