### PR TITLE
Fix issue with unescaped - in regex

### DIFF
--- a/src/scripts/jenkins.coffee
+++ b/src/scripts/jenkins.coffee
@@ -11,7 +11,7 @@
 # jenkins list - lists Jenkins jobs
 #
 module.exports = (robot) ->
-  robot.respond /jenkins build ([\w\.-_]+)( with (.+))?/i, (msg) ->
+  robot.respond /jenkins build ([\w\.\-_]+)( with (.+))?/i, (msg) ->
 
     url = process.env.HUBOT_JENKINS_URL
     job = msg.match[1]


### PR DESCRIPTION
Sorry, previous version didn't correctly escape the -. None of my jobs had a - so I missed it :( But this happy customer didn't.

https://twitter.com/jhigman/status/155271839667601408
