### PR TITLE
Make karma a little more fun

### DIFF
--- a/src/scripts/karma.coffee
+++ b/src/scripts/karma.coffee
@@ -55,12 +55,12 @@ module.exports = (robot) ->
   robot.hear /(\S+[^+\s])\+\+(\s|$)/, (msg) ->
     subject = msg.match[1].toLowerCase()
     karma.increment subject
-    msg.reply "#{subject} #{karma.incrementResponse()} (Karma: #{karma.get(subject)})"
+    msg.send "#{subject} #{karma.incrementResponse()} (Karma: #{karma.get(subject)})"
   
   robot.hear /(\S+[^-\s])--(\s|$)/, (msg) ->
     subject = msg.match[1].toLowerCase()
     karma.decrement subject
-    msg.reply "#{subject} #{karma.decrementResponse()} (Karma: #{karma.get(subject)})"
+    msg.send "#{subject} #{karma.decrementResponse()} (Karma: #{karma.get(subject)})"
   
   robot.respond /karma ?(\S+[^-\s])?$/i, (msg) ->
     if msg.match[1]


### PR DESCRIPTION
This commit fixes an issue where the karma for a subject wasn't being returned, and alters the message from the dreary "The operation succeeded" to something more interesting.

```
Hubot> hubot++
Hubot> hubot gained a level! (Karma: 1)
Hubot> hubot karma hubot
Hubot> "hubot" has 1 karma.
Hubot> hubot++
Hubot> hubot is on the rise! (Karma: 2)
Hubot> hubot--
Hubot> hubot lost a life. (Karma: 1)
```
