### PR TITLE
Let web.coffee follow 302 redirects

### DIFF
--- a/src/scripts/web.coffee
+++ b/src/scripts/web.coffee
@@ -12,8 +12,7 @@ module.exports = (robot) ->
       msg
         .http(url)
         .get() (err, res, body) ->
-          if res.statusCode is 301
-            msg.send "Redirect: " + res.headers.location
+          if res.statusCode is 301 or res.statusCode is 302
             httpResponse(res.headers.location)
           else if res.statusCode is 200
             handler = new HtmlParser.DefaultHandler()


### PR DESCRIPTION
Currently web.coffee only follows 301 redirects but lots of things (like git.io , e.g.) use 302 instead. Just a simple patch to cut down on the "Error: 302" messages.
