### PR TITLE
Add UDP messages to Hubot

### DIFF
--- a/src/scripts/cat.coffee
+++ b/src/scripts/cat.coffee
@@ -1,0 +1,15 @@
+# Send messages to channels via hubot
+#
+# $ echo "#channel|hello everyone" | nc -u -w1 bot_hostname bot_port
+# $ echo "nickname|hello mister" | nc -u -w1 bot_hostname bot_port
+dgram = require "dgram"
+server = dgram.createSocket "udp4"
+
+module.exports = (robot) ->
+  server.on 'message', (message, rinfo) ->
+    msg = message.toString().trim().split("|")
+    target = msg[0]
+    console.log("Sending '#{msg[1]}' to '#{target}'");
+    user = { room: target }
+    robot.send user, msg[1]
+  server.bind(parseInt(process.env.HUBOT_CAT_PORT))


### PR DESCRIPTION
Open a UDP port that Hubot listens on and then you can pipe messages that is sent to any of Hubots rooms/channels.

Syntax of the messages are room|message

Example campfire message (`roomid|message`), send a message to room with id `1337`
`$ echo "1337|Hello from UDP-cat!" | nc -u -w1 localhost 31113`

Example IRC message (`channel or user|message`), send a message to the `#hubot` channel.
`$ echo "#hubot|Hello from UDP-cat!" | nc -u -w1 localhost 31113`

To set what port Hubot should listen on use the variable `HUBOT_CAT_PORT`
