### PR TITLE
Added /text for sending SMS messages using the SMSified API

### DIFF
--- a/src/scripts/text.coffee
+++ b/src/scripts/text.coffee
@@ -32,7 +32,7 @@ module.exports = (robot) ->
       return
 
     msg.http("https://api.smsified.com")
-      .path("/v1/smsmessaging/outbound/{senderAddress}/requests")
+      .path("/v1/smsmessaging/outbound/#{senderAddress}/requests")
       .header("Authorization", auth)
       .header("Content-Type", "application/x-www-form-urlencoded")
       .post(data) (err, res, body) ->


### PR DESCRIPTION
Allows Hubot to send text messages using SMSified API (http://smsified.com).

text <phonenumber> <message> - Sends <message> to <phonenumber>.

You will need to add the following environment variables to use this bot:

heroku config:add HUBOT_SMSIFIED_USERNAME="your_smsified_username"
heroku config:add HUBOT_SMSIFIED_PASSWORD="your_smsified_password"
heroku config:add HUBOT_SMSIFIED_SENDERADDRESS="your_smsified_senderAddress"
