### PR TITLE
Fix `file-brain.coffee`.

### DIFF
--- a/src/scripts/file-brain.coffee
+++ b/src/scripts/file-brain.coffee
@@ -1,20 +1,19 @@
-Url  = require "url"
 fs   = require 'fs'
 path = require 'path'
 
 
 # sets up hooks to persist the brain into file.
 module.exports = (robot) ->
-  brainPath   = process.env.FILE_BRAIN_PATH || '/var/hubot/brain'
-  brainPath   = path.join brainPath 'brain'
-  
-  fs.readFile brainPath, (err, data) ->
-    if err
-      throw err
-    else if data
-      robot.brain.mergeData JSON.parse(data.toString())
-      robat.brain.emit 'load', robot.brain.data
+  brainPath = process.env.FILE_BRAIN_PATH or '/var/hubot'
+  brainPath = path.join brainPath, 'brain-dump.json'
+
+  try
+    data = fs.readFileSync brainPath, 'utf-8'
+    if data
+      robot.brain.mergeData JSON.parse(data)
+      robot.brain.emit 'load', robot.brain.data
+  catch error
+      console.log('Unable to read file', error) unless error.code is 'ENOENT'
 
   robot.brain.on 'save', (data) ->
-    fs.writeFile brainPath, JSON.stringify data, () ->
-      return
+    fs.writeFileSync brainPath, JSON.stringify(data), 'utf-8'


### PR DESCRIPTION
The previously pushed `file-brain` contained a typo calling the `robot` variable a `robat` and used `(read|write)Async` functions and for some reasons were queuing up on my FS.

Also removed a useless `require 'url'`, fixed a syntax error on `path.join` and made the code work.
