### PR TITLE
Added NSFW warning to wat

### DIFF
--- a/src/scripts/wat.coffee
+++ b/src/scripts/wat.coffee
@@ -1,4 +1,4 @@
-# Get a random WAT image
+# Get a random WAT image - warning, this includes NSFW content!
 #
 # wat - Random WAT
 


### PR DESCRIPTION
I had to delete a whole day's transcript from Campfire because wat.coffee pulled in some raunchy content. My bad for not previewing it first, but I thought a warning was in order.
