### PR TITLE
Fixed regex for multiword resorts. Handle CA special case.

### DIFF
--- a/src/scripts/snow.coffee
+++ b/src/scripts/snow.coffee
@@ -7,10 +7,17 @@ xml2js = require('xml2js')
 
 module.exports = (robot) ->
   robot.respond /snow in (\w+)/i, (msg) ->
-    get_snow_report(msg, "http://www.onthesnow.com/#{msg.match[1]}/snow.rss", null)
-  robot.respond /snow at (\w+), (\w+)/i, (msg) ->
-    get_snow_report(msg, "http://www.onthesnow.com/#{msg.match[2]}/snow.rss",msg.match[1])
+    snow_report(msg, msg.match[1], null)
+  robot.respond /snow at (.+), (\w+)/i, (msg) ->
+    snow_report(msg, msg.match[2], msg.match[1])
 
+
+snow_report = (msg, state, resort) ->
+  if state == "CA"
+    # onthesnow splits CA into CN and CS but they have the same resorts
+    get_snow_report(msg,"http://www.onthesnow.com/CN/snow.rss",resort)
+  else
+    get_snow_report(msg,"http://www.onthesnow.com/#{state}/snow.rss",resort)
 
 get_snow_report = (msg, url, resort) ->
   msg.http(url)
@@ -24,8 +31,10 @@ get_snow_report = (msg, url, resort) ->
         parser.parseString body, (err, result) ->
           if err
             msg.send "Got: #{err}"
+          output = ""
           for area in result.channel.item
             if resort? and resort == area.title
-              msg.send "#{area.title} - #{area.description}"
+              output =  "#{area.title} - #{area.description}"
             else
-              msg.send "#{area.title} - #{area.description}" unless resort?
+              output += "#{area.title} - #{area.description}\n" unless resort?
+          msg.send output


### PR DESCRIPTION
Fixed regex to handle multiword resorts, e.g. snow at Copper Mountain, CO
onthesnow.com RSS feed for California uses the acronym CN (California North) or CS (California South) but the resorts in both feeds are the same. Handle this special case.
