### PR TITLE
Remove superfluous brain events from persistence scripts.

### DIFF
--- a/src/scripts/file-brain.coffee
+++ b/src/scripts/file-brain.coffee
@@ -11,7 +11,6 @@ module.exports = (robot) ->
     data = fs.readFileSync brainPath, 'utf-8'
     if data
       robot.brain.mergeData JSON.parse(data)
-      robot.brain.emit 'load', robot.brain.data
   catch error
       console.log('Unable to read file', error) unless error.code is 'ENOENT'
 

--- a/src/scripts/redis-brain.coffee
+++ b/src/scripts/redis-brain.coffee
@@ -20,7 +20,6 @@ module.exports = (robot) ->
         throw err
       else if reply
         robot.brain.mergeData JSON.parse(reply.toString())
-        robot.brain.emit 'load', robot.brain.data
 
   robot.brain.on 'save', (data) ->
     client.set 'hubot:storage', JSON.stringify data


### PR DESCRIPTION
I'm not sure why these "load" events are emitted, because brain.mergeData already emits a "loaded" event when it is called. Seems like they could be removed. No other scripts in this repository appear to rely on the "load" event.
