### PR TITLE
Web.coffee now ignores twitter links

### DIFF
--- a/src/scripts/web.coffee
+++ b/src/scripts/web.coffee
@@ -43,8 +43,9 @@ module.exports = (robot) ->
             msg.send if response.status_code is 200 then responseTitle else response.status_txt
           else
             httpResponse(url)
-
-    if url.match /^http\:\/\/bit\.ly/
+    if url.match /https?:\/\/(mobile\.)?twitter\.com/i
+      console.log "Twitter link; ignoring"
+    else if url.match /^http\:\/\/bit\.ly/
       httpBitlyResponse(url)
     else
       httpResponse(url)


### PR DESCRIPTION
Twitter can be superseded by tweet-content.coffee, so I've removed them from web.coffee.
