### PR TITLE
Show Magic: The Gathering card art in chat

### DIFF
--- a/src/scripts/mtg.coffee
+++ b/src/scripts/mtg.coffee
@@ -1,0 +1,13 @@
+#
+# Insert Pictures of Magic: The Gathering Cards
+#
+# cast <card name> - a picture of the named magic card
+
+querystring = require 'querystring';
+
+module.exports = (robot) ->
+  robot.respond /cast (.+)/i, (msg) ->
+    url = "http://gatherer.wizards.com/Handlers/Image.ashx"
+    card = msg.match[1] || "Dismal%20Failure"
+    query = { type: "card", name: card }
+    msg.send "#{url}?#{querystring.stringify(query)}#.jpg"


### PR DESCRIPTION
Hubot will fetch Magic card images from gatherer.wizards.com

example usage:
hubot cast black cat
