### PR TITLE
Announce changes to Bitbucket repositories

### DIFF
--- a/src/scripts/bitbucket.coffee
+++ b/src/scripts/bitbucket.coffee
@@ -1,0 +1,21 @@
+# Announce changes to BitBucket repositories using BitBucket's POST service
+# to a room sepecified by the URL.
+# 
+# For instructions on how to set up BitBucket's POST service for your repositories,
+# visit: http://confluence.atlassian.com/display/BITBUCKET/Setting+Up+the+bitbucket+POST+Service
+#
+
+module.exports = (robot) ->
+  robot.router.post '/hubot/bitbucket/:room', (req, res) ->
+    room = req.params.room
+    
+    data = JSON.parse req.body.payload
+    commits = data.commits
+      
+    msg = "#{data.user} pushed #{commits.length} commits to #{data.repository.name}:\n\n"
+    msg += "[#{commit.branch}] #{commit.message}\n" for commit in commits
+    
+    robot.messageRoom room, msg
+      
+    res.writeHead 204, { 'Content-Length': 0 }
+    res.end()


### PR DESCRIPTION
Hubot will announce and summarize when changes are pushed to bitbucket repositories.
