### PR TITLE
Preserve full URL in keep-alive script

### DIFF
--- a/src/scripts/keep-alive.coffee
+++ b/src/scripts/keep-alive.coffee
@@ -16,7 +16,7 @@ ping = (url) ->
   options   =
     host: parsedUrl.host
     port: 80
-    path: '/'
+    path: parsedUrl.path
     method: 'GET'
 
   req = HTTP.request options, (res) ->


### PR DESCRIPTION
Change the keep-alive script to ping the full URL originally specified provided, instead of just the root of the domain.
