### PR TITLE
Fixes redmine header comment

### DIFF
--- a/src/scripts/redmine.coffee
+++ b/src/scripts/redmine.coffee
@@ -6,7 +6,7 @@
 #                                                     *With optional notes
 # update <issue-id> with "<note>"  - Adds a note to the issue
 # add <hours> hours to <issue-id> ["comments"]  - Adds hours to the issue with the optional comments
-#
+
 # Note: <issue-id> can be formatted in the following ways:
 #       1234, #1234, issue 1234, issue #1234
 #


### PR DESCRIPTION
This is a really small change, but it bothered me.

In redmine.coffee the top comment is formatted such that the whole comment is used in hubot's help listing.
By inserting a blank line between the relevant comment and the documenting comment, hubot uses just the top part.
