### PR TITLE
Actually shows 'current' stories not all.

### DIFF
--- a/src/scripts/pivotal.coffee
+++ b/src/scripts/pivotal.coffee
@@ -26,13 +26,13 @@ module.exports = (robot) ->
       (new Parser).parseString body, (err, json)->
         for project in json.project
           if project_name.test(project.name)
-            msg.http("https://www.pivotaltracker.com/services/v3/projects/#{project.id}/stories").headers("X-TrackerToken": token).query(filter: "state:unstarted,started,finished,delivered").get() (err, res, body) ->
+            msg.http("https://www.pivotaltracker.com/services/v3/projects/#{project.id}/iterations/current").headers("X-TrackerToken": token).query(filter: "state:unstarted,started,finished,delivered").get() (err, res, body) ->
               if err
                 msg.send "Pivotal says: #{err}"
                 return
       
               (new Parser).parseString body, (err, json)->
-                for story in json.story
+                for story in json.iteration.stories.story
                   message = "##{story.id['#']} #{story.name}"
                   message += " (#{story.owned_by})" if story.owned_by
                   message += " is #{story.current_state}" if story.current_state && story.current_state != "unstarted"


### PR DESCRIPTION
After getting Pivotal Tracker working with Hubot was surprised to see the default for this to be 'show all stories' instead of 'show current stories'.

IMO based on Pivotal's API this class has a lot of potential with regards to showing stories based on iteration, filter, etc... Will see if I can pick up the reigns on this and get a couple more commands for Pivotal.
