### PR TITLE
pivotal.coffee whitespace issue

### DIFF
--- a/src/scripts/pivotal.coffee
+++ b/src/scripts/pivotal.coffee
@@ -10,7 +10,7 @@
 #
 # show me stories for <project> -- shows current stories being worked on
 module.exports = (robot) ->
-  robot.respond /show\s+(me\s+)?stories\s+(for\s+)?(.*)/i, (msg)->
+  robot.respond /show\s+(me\s+)?stories(\s+for\s+)?(.*)/i, (msg)->
     Parser = require("xml2js").Parser
     token = process.env.HUBOT_PIVOTAL_TOKEN
     project_name = msg.match[3]


### PR DESCRIPTION
When a single pivotal project is set via the HUBOT_PIVOTAL_PROJECT environment variable, `show stories` does not work. `show stories` (with trailing whitespace) does. I have tweaked the regex to fix this.
