### PR TITLE
Don't forget the port for url in redmine

### DIFF
--- a/src/scripts/redmine.coffee
+++ b/src/scripts/redmine.coffee
@@ -286,6 +286,7 @@ class Redmine
 
     options =
       "host"   : endpoint.hostname
+      "port"   : endpoint.port
       "path"   : "#{pathname}#{path}"
       "method" : method
       "headers": headers


### PR DESCRIPTION
I added the port parameter to build the http request

```
 options =
   "host"   : endpoint.hostname
```
-      "port"   : endpoint.port
     "path"   : "#{pathname}#{path}"
     "method" : method
     "headers": headers
