### PR TITLE
Add a 'decide' script

### DIFF
--- a/src/scripts/decide.coffee
+++ b/src/scripts/decide.coffee
@@ -1,0 +1,15 @@
+# Allows Hubot to help you decide between multiple options.
+#
+# decide "<option1>" "<option2>" "<optionx>" - Randomly picks an option.
+#                                        More fun than using a coin.
+#
+# Examples:
+#
+# decide "Vodka Tonic" "Tom Collins" "Rum & Coke"
+# decide "Stay in bed like a lazy bastard" "You have shit to code, get up!"
+#
+
+module.exports = (robot) ->
+  robot.respond /decide "(.*)"/i, (msg) ->
+    options = msg.match[1].split('" "')
+    msg.reply("Definitely \"#{ msg.random options }\".")


### PR DESCRIPTION
Sometimes you just want more options than heads or tails. decide.coffee adds a method to decide between multiple quoted options, separated by spaces.

e.g.
<logikal> hubot: decide "Vodka Tonic" "Tom Collins" "Rum & Coke"
<hubot> Definitely "Vodka Tonic".
