### PR TITLE
Hubot can now speak Erlang.

### DIFF
--- a/src/scripts/tryerlang.coffee
+++ b/src/scripts/tryerlang.coffee
@@ -1,0 +1,14 @@
+# erl <expr> - Evaluate an Erlang Expression on tryerlang.org and return the result
+#
+# By Roberto Aloi (@robertoaloi)
+
+QS = require "querystring"
+
+module.exports = (robot) ->
+  robot.respond /(tryerlang|erl) (.*)/i, (msg) ->
+    expr = msg.match[2]
+    data = QS.stringify({'expression': expr})
+    msg.http('http://www.tryerlang.org/api/eval/default/intro')
+      .post(data) (err, res, body) ->
+        response = JSON.parse(body)
+        msg.send response.result


### PR DESCRIPTION
This script allows Hubot to execute Erlang expressions via the tryerlang.org APIs.

Usage example:

<pre>
Hubot> hubot erl erlang:time().
Hubot> {4,41,19}
Hubot> hubot erl 24+123.
Hubot> 147
Hubot> hubot erl lists:seq(1,19) ++ [20].
Hubot> [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]
</pre>


I'm completely new to Hubot, Node and Coffee, so comments and critics are more than welcome.
