### PR TITLE
Add javabot style factoids

### DIFF
--- a/src/scripts/factoid.coffee
+++ b/src/scripts/factoid.coffee
@@ -1,5 +1,12 @@
-class Factoids
+# javabot style factoid support for your hubot. Build a factoid library
+# and save yourself typing out answers to similar questions.
+#
+# ~<factoid> is <some phrase, link, whatever> - Creates or updates a factoid.
+# ~<factoid> - Prints the factoid, if it exists. Otherwise tells you there is no factoid.
+# ~tell <user> about <factoid> - Tells the user about a factoid, if it exists.
+# ~~<user> <factoid> - Same as ~tell, less typing.
 
+class Factoids
   constructor: (@robot) ->
     @robot.brain.on 'loaded', =>
       @cache = @robot.brain.data.factoids


### PR DESCRIPTION
I've always found the factoids plugin in javabot to be helpful. This is an implementation of some of the factoid features. Includes:
- adding factoids
- getting factoids
- telling users about a factoid

Some way to see all factoids might be nice to add in the future (javabot has a web interface for them).

Let me know what you think, thanks!
