### PR TITLE
Plugin to search/show saved graphs from a Graphite server

### DIFF
--- a/src/scripts/graphite.coffee
+++ b/src/scripts/graphite.coffee
@@ -3,11 +3,6 @@
 # hubot graphite search <string> - search for graph by name
 # hubot graphite show <graph.name> - output graph
 #
-# prerequisites:
-#  * have accounts on both mysqueezebox.com & pandora
-#  * have the pandora app installed on squeezebox
-#  * be signed into your pandora account on mysqueezebox.com
-#
 # set the env variables:
 #  * GRAPHITE_URL (e.g. https://graphite.example.com)
 #  * GRAPHITE_PORT (e.g. 8443)


### PR DESCRIPTION
This plugin offers functionality for searching and displaying graphs from the saved Graphs tree of a Graphite installation. It does this by traversing the navigation tree via the Graphite API and filtering on the search string. Future improvements will include DRYing up the code and possibly adding similar features for raw metrics.
