### PR TITLE
Update url.coffee with a proper URL encoding/decoding

### DIFF
--- a/src/scripts/url.coffee
+++ b/src/scripts/url.coffee
@@ -1,19 +1,26 @@
 # URL encoding and decoding.
 #
 # url encode|decode <query> - URL encode or decode <string>
+# url form encode|decode <query> - URL form-data encode or decode <string>
 
 module.exports = (robot) ->
   robot.respond /URL encode( me)? (.*)/i, (msg) ->
-    msg.send urlEncode(msg.match[2])
+    msg.send encodeURIComponent(msg.match[2])
 
   robot.respond /URL decode( me)? (.*)/i, (msg) ->
-    msg.send urlDecode(msg.match[2])
+    msg.send decodeURIComponent(msg.match[2])
 
-# url encoding helpers (shamelessly ripped from `jshashes` npm package)
-urlEncode = (str) ->
+  robot.respond /URL form encode( me)? (.*)/i, (msg) ->
+    msg.send urlFormEncode(msg.match[2])
+
+  robot.respond /URL form decode( me)? (.*)/i, (msg) ->
+    msg.send urlFormDecode(msg.match[2])
+
+# url form-data encoding helpers (partially ripped from jshashes npm package)
+urlFormEncode = (str) ->
   escape(str)
     .replace(new RegExp('\\+','g'),'%2B')
     .replace(new RegExp('%20','g'),'+')
 
-urlDecode = (str) ->
+urlFormDecode = (str) ->
   unescape(str.replace(new RegExp('\\+','g'), ' '))


### PR DESCRIPTION
The old behavior is still available via `url form encode|decode`. Form-data encoding uses `+` for spaces instead of `%20` as "raw" URL encoding does.

For details, see: http://stackoverflow.com/a/996161/42146
