### PR TITLE
Hubot will respond to 'thanks hubot' as well as 'hubot thanks'

### DIFF
--- a/src/scripts/polite.coffee
+++ b/src/scripts/polite.coffee
@@ -33,14 +33,14 @@ youTalkinToMe = (msg, robot) ->
   input.indexOf(name) != -1
 
 module.exports = (robot) ->
-  robot.respond /(thanks|thank you|cheers|nice one)/i, (msg) ->
+  robot.hear /(thanks|thank you|cheers|nice one)/i, (msg) ->
     msg.reply msg.random responses if youTalkinToMe(msg, robot)
 
-  robot.respond /(ty|thx)/i, (msg) ->
+  robot.hear /(ty|thx)/i, (msg) ->
     msg.reply msg.random shortResponses if youTalkinToMe(msg, robot)
 
-  robot.respond /(hello|hi|sup|howdy|good (morning|evening|afternoon))/i, (msg) ->
+  robot.hear /(hello|hi|sup|howdy|good (morning|evening|afternoon))/i, (msg) ->
     msg.reply "#{robot.name} at your service!" if youTalkinToMe(msg, robot)
     
-  robot.respond /(bye|night|goodbye|good night)/i, (msg) ->
+  robot.hear /(bye|night|goodbye|good night)/i, (msg) ->
     msg.reply msg.random farewellResponses if youTalkinToMe(msg, robot)


### PR DESCRIPTION
Changed the "polite" script to respond when hubot's thanked in any order, not just when hubot is thanked in command-like syntax ("hubot thank you") for a more natural-feeling robot.
