### PR TITLE
Fix for crash when the message has a null user.  Problem experienced wit...

### DIFF
--- a/src/scripts/conversation.coffee
+++ b/src/scripts/conversation.coffee
@@ -17,7 +17,7 @@ module.exports = (robot) ->
   # Change default receive command, addind processing of eatListeners
   robot.origReceive = robot.receive
   robot.receive = (message) ->
-    if robot.eatListeners[message.user.id]?
+    if message.user? and robot.eatListeners[message.user.id]?
       lst = robot.eatListeners[message.user.id]
       delete robot.eatListeners[message.user.id]
 


### PR DESCRIPTION
...h HipChat adapter.

/opt/hubot/node_modules/hubot-scripts/src/scripts/conversation.coffee:13
      if (robot.eatListeners[message.user.id] != null) {
                                         ^
TypeError: Cannot read property 'id' of undefined
    at Robot.receive (/opt/hubot/node_modules/hubot-scripts/src/scripts/conversation.coffee:13:42)
    at Robot.origReceive (/opt/hubot/node_modules/hubot/src/robot.coffee:120:21)
    at Robot.receive (/opt/hubot/node_modules/hubot-scripts/src/scripts/conversation.coffee:21:20)
    at HipChat.receive (/opt/hubot/node_modules/hubot/src/adapter.coffee:44:25)
    at Bot.<anonymous> (/opt/hubot/node_modules/hubot-hipchat/src/hipchat.coffee:127:21)
    at Bot.emit (events.js:77:17)
    at Bot.<anonymous> (/opt/hubot/node_modules/hubot-hipchat/node_modules/wobot/lib/bot.js:108:12)
    at Client.<anonymous> (native)
    at Client.emit (events.js:67:17)
    at Client.onRawStanza (/opt/hubot/node_modules/hubot-hipchat/node_modules/wobot/node_modules/node-xmpp/lib/xmpp/client.js:159:14)
