### PR TITLE
Add a /janky endpoint for janky notifications.

### DIFF
--- a/src/scripts/janky.coffee
+++ b/src/scripts/janky.coffee
@@ -138,3 +138,7 @@ module.exports = (robot) ->
         response += "\n" if count > 1
 
       msg.send response
+
+  robot.router.post "/janky", (req, res) ->
+    robot.messageRoom req.body.room, req.body.message
+    res.end "ok"


### PR DESCRIPTION
See github/janky#72.

The idea is to remove any chat_service from janky and to use hubot.

However, using messageRoom is not perfect, see github/hubot#234.
