### PR TITLE
Allowing Retweets to Come Through from the Twitter Script

### DIFF
--- a/src/scripts/twitter.coffee
+++ b/src/scripts/twitter.coffee
@@ -2,7 +2,7 @@
 module.exports = (robot) ->
   robot.respond /(twitter|lasttweet) (.+)$/i, (msg) ->
    username = msg.match[2]
-   msg.http("http://api.twitter.com/1/statuses/user_timeline/#{escape(username)}.json?count=1")
+   msg.http("http://api.twitter.com/1/statuses/user_timeline/#{escape(username)}.json?count=1&include_rts=true")
     .get() (err, res, body) ->
       response = JSON.parse body
       if response[0]


### PR DESCRIPTION
Currently, if you use the twitter script to retrieve the latest tweet from a user and that latest tweet is a retweet, the script returns "Error". This appears to be because the twitter API factors in retweets (native ones) into it's counts but does not, by default, return these retweets. So the "count=1" query string param gets the latest tweets (including retweets) but the actual service will only return a "[]" without this additional query string parameter. 
