### PR TITLE
Use screen_name instead of name

### DIFF
--- a/src/scripts/tweet-content.coffee
+++ b/src/scripts/tweet-content.coffee
@@ -6,4 +6,4 @@ module.exports = (robot) ->
 
 			tweet = JSON.parse(body)
 
-			msg.send "@#{tweet.user.name}: #{tweet.text}"
+			msg.send "@#{tweet.user.screen_name}: #{tweet.text}"


### PR DESCRIPTION
Annoying when the msg says "@Simon Gate: message", should say "@simongate: message" instead ( this PR fixes that problem).
