### PR TITLE
Quote HUBOT_PLAY_TOKEN.

### DIFF
--- a/src/scripts/play.coffee
+++ b/src/scripts/play.coffee
@@ -27,7 +27,7 @@ URL = "#{process.env.HUBOT_PLAY_URL}"
 
 authedRequest = (message, path, action, options, callback) ->
   message.http("#{URL}#{path}")
-    .query(login: message.message.user.githubLogin, token: process.env.HUBOT_PLAY_TOKEN)
+    .query(login: message.message.user.githubLogin, token: "#{process.env.HUBOT_PLAY_TOKEN}")
     .header('Content-Length', 0)
     .query(options)[action]() (err, res, body) ->
       callback(err,res,body)


### PR DESCRIPTION
Currently using Play commands with Hubot completely break, throwing very odd error message shown in play/play#163. 

Turns out the variable needs to be quoted. I could've quoted the token in Heroku, but having run into other people whom have also inputted their tokens without quotes, this seems like a better course of action.
