### PR TITLE
Add "whatis" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
   "dependencies": {
     "hubot": ">= 2.0.4",
     "optparse": "1.0.3",
-    "redis": "0.6.7",
-    "jquery": "1.7.2",
-    "jsdom": "0.2.14"
+    "redis": "0.6.7"
   },
 
   "directories":  {


### PR DESCRIPTION
During IRC conversation, there's always occasions where someone says something and you have no idea what is is. Now, with the 'whatis' command, you can get yourself educated and don't have to feel like a moron any more :)

with `hubot whatis <search_term>`, hubot will search the term on urbandictionary.com (always a good source of reference ;) ), and get a random definition from the most popular definitions.
