### PR TITLE
Hubot entering infinite loop on issue search in FlowDock

### DIFF
--- a/src/scripts/jira.coffee
+++ b/src/scripts/jira.coffee
@@ -177,7 +177,7 @@ module.exports = (robot) ->
     search msg, msg.match[2], (text) ->
       msg.reply text
   
-  robot.hear /([^\w\-]|^)(\w+-[0-9]+)(?=[^\w]|$)/ig, (msg) ->
+  robot.respond /([^\w\-]|^)(\w+-[0-9]+)(?=[^\w]|$)/ig, (msg) ->
     if msg.message.user.id is robot.name
       return
 


### PR DESCRIPTION
Had issues with hubot entering an infinite loop when responding to an issue search, even when setting HUBOT_JIRA_IGNOREUSERS and HUBOT_JIRA_ISSUEDELAY
