### PR TITLE
Updated to allows spaces in job names / Changed delimiter for parameterized builds to ,

### DIFF
--- a/src/scripts/jenkins.coffee
+++ b/src/scripts/jenkins.coffee
@@ -7,13 +7,15 @@
 #   HUBOT_JENKINS_AUTH: for authenticating the trigger request (user:password)
 #
 # jenkins build <job> - builds the specified Jenkins job
-# jenkins build <job> with <params> - builds the specified Jenkins job with parameters as key=value&key2=value2
+# jenkins build <job>,  <params> - builds the specified Jenkins job with parameters as key=value&key2=value2
 # jenkins list - lists Jenkins jobs
 #
 
+querystring = require 'querystring'
+
 jenkinsBuild = (msg) ->
     url = process.env.HUBOT_JENKINS_URL
-    job = msg.match[1]
+    job = querystring.escape msg.match[1]
     params = msg.match[3]
 
     path = if params then "#{url}/job/#{job}/buildWithParameters?#{params}" else "#{url}/job/#{job}/build"
@@ -57,7 +59,7 @@ jenkinsList = (msg) ->
             msg.send error
 
 module.exports = (robot) ->
-  robot.respond /jenkins build ([\w\.\-_]+)( with (.+))?/i, (msg) ->
+  robot.respond /jenkins build ([\w\.\-_ ]+)(, (.+))?/i, (msg) ->
     jenkinsBuild(msg)
 
   robot.respond /jenkins list/i, (msg) ->


### PR DESCRIPTION
Updated to allows spaces in job names (this is legit in Jenkins)
Changed spec so that the delimiter between build and build with parameters is a comma - no more " with "
Properly url escaping characters like spaces when triggering the job
