### PR TITLE
Make redis-brain less noisy during startup

### DIFF
--- a/src/scripts/redis-brain.coffee
+++ b/src/scripts/redis-brain.coffee
@@ -13,7 +13,7 @@ module.exports = (robot) ->
     robot.logger.error err
 
   client.on "connect", ->
-    robot.logger.info "Successfully connected to Redis"
+    robot.logger.debug "Successfully connected to Redis"
 
     client.get "hubot:storage", (err, reply) ->
       if err


### PR DESCRIPTION
It currently uses `logger.info` to log a successful connect to redis. It
probably should be debug instead.
