### PR TITLE
Issue with acitvity script.

### DIFF
--- a/src/scripts/github-activity.coffee
+++ b/src/scripts/github-activity.coffee
@@ -7,6 +7,7 @@
 # 
 # Configuration:
 #   HUBOT_GITHUB_TOKEN
+#   HUBOT_GITHUB_USER
 #
 # Commands:
 #   hubot repo show <repo> - shows activity of repository
@@ -20,7 +21,6 @@ module.exports = (robot) ->
   github = require("githubot")(robot)
   robot.respond /repo show (.*)$/i, (msg) ->
     repo = github.qualified_repo msg.match[1]
-    oauth_token = process.env.HUBOT_GITHUB_TOKEN
     url = "https://api.github.com/repos/#{repo}/commits"
 
     github.get url, (commits) ->


### PR DESCRIPTION
I'm not sure if I'm missing something, but according to what I could grasp from githubot, the activity script should have configured the HUBOT_GITHUB_USER. If I don't add this variable, then I get 404 when trying to query my repos.

I also delete the oauth variable, because githubot is requesting the proccess.env directly.

Cheers.
