### PR TITLE
Added a "Jenkins describe" action

### DIFF
--- a/src/scripts/jenkins.coffee
+++ b/src/scripts/jenkins.coffee
@@ -63,12 +63,19 @@ jenkinsDescribe = (msg) ->
           try
             content = JSON.parse(body)
             response += "JOB: #{content.displayName}\n"
-            response += "DESCRIPTION: #{content.description}\n"
+
+            if content.description
+              response += "DESCRIPTION: #{content.description}\n"
+            
             response += "ENABLED: #{content.buildable}\n"
             response += "STATUS: #{content.color}\n"
+            
             tmpReport = ""
-            for report in content.healthReport
-              tmpReport += "\n  #{report.description}"
+            if content.healthReport.length > 0
+              for report in content.healthReport
+                tmpReport += "\n  #{report.description}"
+            else
+              tmpReport = " unknown"
             response += "HEALTH: #{tmpReport}\n"
 
             parameters = ""


### PR DESCRIPTION
I've added an action to the Jenkins script to describe a job.  It's pretty simple:  "jenkins describe <job>" prints out things like name, status, health, description, build parameters (if applicable).

Please consider merging it in if you think others would find it useful.

Thanks!!!!!

(I'm a pull-request novice, so please understand if I have the range wrong)
