### PR TITLE
Renamed CoffeeScript reserved word "package" to "pkg"

### DIFF
--- a/src/scripts/pypi.coffee
+++ b/src/scripts/pypi.coffee
@@ -20,32 +20,32 @@ createClient = ->
     return new pypi.Client process.env.HUBOT_PYPI_URL or "http://pypi.python.org/pypi"
 
 
-showLatestPackage = (msg, package) ->
+showLatestPackage = (msg, pkg) ->
     client = createClient()
-    client.getPackageReleases package, (versions) ->
+    client.getPackageReleases pkg, (versions) ->
         if versions.length
             latestVersion = versions.sort()[versions.length - 1]
-            msg.send "Latest version of #{package} is #{latestVersion}"
+            msg.send "Latest version of #{pkg} is #{latestVersion}"
 
-showTotalDownloads = (msg, package) ->
+showTotalDownloads = (msg, pkg) ->
     client = createClient()
-    client.getPackageReleases package, (versions) ->
+    client.getPackageReleases pkg, (versions) ->
         totalDownloads = 0
         todo = versions.length
         for version in versions
-            client.getReleaseDownloads package, version, (downloads) ->
+            client.getReleaseDownloads pkg, version, (downloads) ->
                 for count in (e[1] for e in downloads)
                     totalDownloads += count
                 todo -= 1
                 if todo == 0
-                    msg.send "Total downloads of #{package}: #{totalDownloads}"
+                    msg.send "Total downloads of #{pkg}: #{totalDownloads}"
 
 module.exports = (robot) ->
 
     robot.respond /show latest from pypi for (.*)/i, (msg) ->
-        package = msg.match[1]
-        showLatestPackage msg, package
+        pkg = msg.match[1]
+        showLatestPackage msg, pkg
 
     robot.respond /show total downloads from pypi for (.*)/i, (msg) ->
-        package = msg.match[1]
-        showTotalDownloads msg, package
+        pkg = msg.match[1]
+        showTotalDownloads msg, pkg


### PR DESCRIPTION
CoffeeScript 1.3.3 complains about using "package" as a variable name so I renamed it.
