### PR TITLE
Fix regexp in shorten.coffee

### DIFF
--- a/src/scripts/shorten.coffee
+++ b/src/scripts/shorten.coffee
@@ -15,7 +15,7 @@
 #   sleekslush
 
 module.exports = (robot) ->
-  robot.respond /(bitly|shorten)\s?(me)?\s?(.+)$/, (msg) ->
+  robot.respond /(bitly|shorten)\s?(me)?\s?(.+)$/i, (msg) ->
     msg
       .http("http://api.bitly.com/v3/shorten")
       .query


### PR DESCRIPTION
Not sure why this doesn't match lower-case strings, but doesn't seem to work without the flag.
