### PR TITLE
filter some filetypes from being pulled; handle undefined title

### DIFF
--- a/src/scripts/http-info.coffee
+++ b/src/scripts/http-info.coffee
@@ -30,8 +30,9 @@ module.exports = (robot) ->
           unless errors
             $ = window.$
             title = $('title').text()
-            description = "\n" + $('meta[name=description]').attr("content")
-
+            description = $('meta[name=description]').attr("content") || ""
+            description = "\n" + description if description
+            
             if title
               msg.send "#{title}#{description}"
         )


### PR DESCRIPTION
A few minor changes so we don't throw "undefined" if no title exists, and so we don't bother looking up images.
