### PR TITLE
Adding files to hubot-scripts.json is no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ of all the available scripts.
 ## Installing
 
 Once you have Hubot installed, you can drop new scripts from this repository
-right into your generated Hubot installation. Just put them in `scripts`, add
-the new scripts to the `hubot-scripts.json` file.
+right into your generated Hubot installation. Just put them in the `scripts`
+folder.
 
 Any third-party dependencies for scripts need adding your your `package.json`
 otherwise a lot of errors will be thrown during the start up of your hubot. You
@@ -77,6 +77,6 @@ repository.
 [script-catalog]: http://hubot-script-catalog.herokuapp.com
 [src-scripts]: https://github.com/github/hubot-scripts/tree/master/src/scripts
 [tomdoc]: http://tomdoc.org
-[example-script]: https://github.com/github/hubot-scripts/blob/master/src/scripts/tweet.coffee 
+[example-script]: https://github.com/github/hubot-scripts/blob/master/src/scripts/tweet.coffee
 [hubot-script-tests]: https://github.com/github/hubot-scripts/blob/master/test/tests.coffee
 [example-script-docs]: (https://github.com/github/hubot-scripts/blob/master/src/scripts/speak.coffee#L1-5


### PR DESCRIPTION
hubot-scripts.json doesn't seem to actually do anything and if you do happen to add a core library into this file it will create duplicates. Additionally, if you create your own plugin but it's not in the npm version you get errors in the logs. 

My current hubot-scripts.json just says `[]` and it works superbly. 

I didn't want to go an patch things so that hubot-scripts.json isn't used without first asking if I was missing something. 
