### PR TITLE
[Janky] Request from campfire to run a project in Jenkins fails

### DIFF
--- a/src/scripts/janky.coffee
+++ b/src/scripts/janky.coffee
@@ -77,7 +77,7 @@ module.exports = (robot) ->
     app     = msg.match[1]
     branch  = msg.match[3] || "master"
     room_id = msg.message.user.room
-    user    = msg.message.user.name
+    user    = msg.message.user.name.replace(/\ /g, "+")
 
     post "#{app}/#{branch}?room_id=#{room_id}&user=#{user}", {}, (err, statusCode, body) ->
       if statusCode == 201 or statusCode == 404


### PR DESCRIPTION
Janky is returning a 400 (Bad Request) error at times when a request for a new
build is made. Those errors are due to whitespaces that are being used in user's
names for campfire and possibly another chat engines.

The output I got in campfire is
`Can't go HAM on $repo/$branch, shit's being weird.`
which is triggered by [janky.coffee, line 87](https://github.com/github/hubot-scripts/blob/master/src/scripts/janky.coffee#L87).

Replacement of all spaces for plus signs "+" in user's names makes the URL that
is being posted to from hubot's janky script compliant to the specification [1]
and solves the issue.

[1] http://www.w3.org/Addressing/URL/url-spec.txt
