### PR TITLE
Grab the session ID from the response.

### DIFF
--- a/src/scripts/clojure.coffee
+++ b/src/scripts/clojure.coffee
@@ -13,14 +13,20 @@
 # Author:
 #   jingweno
 
+ringSessionID = ''
+
 module.exports = (robot) ->
   robot.respond /(clojure|clj)\s+(.*)/i, (msg)->
-    script = encodeURIComponent(msg.match[2])
+    script = msg.match[2]
 
-    msg.http("http://tryclj.com/eval.json?expr=#{script}")
+    msg.http("http://tryclj.com/eval.json")
+      .query(expr: script)
+      .headers(Cookie: "ring-session=#{ringSessionID}")
       .get() (err, res, body) ->
         switch res.statusCode
           when 200
+            if res.headers["set-cookie"]
+              ringSessionID = res.headers["set-cookie"][0].match(/ring-session=([-a-z0-9]+);/)[1]
             result = JSON.parse(body)
 
             if result.error


### PR DESCRIPTION
This changeset will grab a Set-Cookie header for "ring-session" coming from http://tryclj.com/. This allows for persistent REPL sessions such as the following.

```
Hubot> hubot: clj (defn say-hi [x] (format "Hi, %s" x))
Hubot> #'sandbox18199/say-hi
Hubot> hubot: clj (say-hi "Steven")
Hubot> "Hi, Steven"
```
