### PR TITLE
Fixed `Working-on.coffee`: incorrect function name

### DIFF
--- a/src/scripts/working-on.coffee
+++ b/src/scripts/working-on.coffee
@@ -31,7 +31,7 @@ module.exports = (robot) ->
 
   robot.respond /(i\'m|i am) working on (.*)/i, (msg) ->
     name = msg.message.user.name
-    user = findUser name
+    user = robot.userForName name
 
     if typeof user is 'object'
       user.workingon = msg.match[2]


### PR DESCRIPTION
The script `working-on.coffee` was not working. The error was that there was no function defined by the name of `findUser`. Changed that to `robot.userForName` and it seems to be working fine.
