### PR TITLE
Cleaned up docs to format properly with 'help'

### DIFF
--- a/src/scripts/github-issues.coffee
+++ b/src/scripts/github-issues.coffee
@@ -13,17 +13,16 @@
 #   HUBOT_GITHUB_USER_(.*)
 #
 # Commands:
-#   If HUBOT_GITHUB_USER is set, you can ask `show me issues for hubot` instead
-#   of `show me issues for github/hubot`.
+#   hubot show [me] [<limit> [of]] [<assignee>'s|my] [<label>] issues [for <user/repo>] [about <query>] -- Shows open GitHub issues for repo.
+#   hubot show me issues for <repo> -- List all issues for given repo IFF GITHUB_USER configured
+#   hubot show me issues for <user/repo> -- List all issues for given repo
+#   hubot show me issues -- Lists all issues IFF GITHUB_REPO configured
+#   hubot show <chat user's> issues -- Lists all issues for chat user IFF HUBOT_GITHUB_USER_(.*) configured
 #
-#   If HUBOT_GITHUB_REPO is set, you can ask `show me issues` instead of `show
-#   me issues for github/hubot`.
-#
+# Notes:
 #   If, for example, HUBOT_GITHUB_USER_JOHN is set to GitHub user login
 #   'johndoe1', you can ask `show john's issues` instead of `show johndoe1's
 #   issues`. This is useful for mapping chat handles to GitHub logins.
-#
-#   hubot show [me] [<limit> [of]] [<assignee>'s|my] [<label>] issues [for <user/repo>] [about <query>] -- Shows open GitHub issues for repo.
 #
 # Author:
 #   davidsiegel


### PR DESCRIPTION
Notes and Hubot commands were previously mixed up, rendering the
Hubot 'help' command messy
