### PR TITLE
Adds display of sparkline chart, if present, for an alert.

### DIFF
--- a/src/scripts/scoutapp.coffee
+++ b/src/scripts/scoutapp.coffee
@@ -38,10 +38,12 @@ module.exports = (robot) ->
     #   "metric_name": "last_minute",
     #   "metric_value": 3.5,
     #   "severity": "warning", // warning = normal threshold, critical = SMS threshold
-    #   "url": "https://scoutapp.com/a/999999"
+    #   "url": "https://scoutapp.com/a/999999",
+    #   "sparkline_url":"https://scoutapp.com/alert_sparkline.png"
     # }
 
     robot.messageRoom room, "Scout #{data.severity} - #{data.server_name} on host #{data.server_hostname} #{data.lifecycle}ed - #{data.plugin_name} - #{data.title} - Current value #{data.metric_name}=#{data.metric_value} - Details: #{data.url}"
+    robot.messageRoom room, data.sparkline_url if data.sparkline_url
 
     # Send back an empty response
     res.writeHead 204, { 'Content-Length': 0 }


### PR DESCRIPTION
The scoutapp.com API added an URL to show a sparkline graph of data associated to an alert. This adds the display of that graph to the campfire room if the sparkline_url is present.
