### PR TITLE
Adds missing _hubot path prefix for GET requests to Janky

### DIFF
--- a/src/scripts/janky.coffee
+++ b/src/scripts/janky.coffee
@@ -27,8 +27,8 @@ defaultOptions = () ->
       "Authorization": "Basic #{auth}"
 
 get = (path, params, cb) ->
-  options = defaultOptions()
-  options.path   = "/_hubot/#{path}"
+  options      = defaultOptions()
+  options.path = "/_hubot/#{path}"
   console.log(options)
   req = HTTP.request options, (res) ->
     body = ""


### PR DESCRIPTION
The _hubot prefix is missing from all GET operations which breaks e.g. the `ci status` and `ci status <repo>` commands.
