### PR TITLE
Add Github commit Linking

### DIFF
--- a/src/scripts/github-commit-link.coffee
+++ b/src/scripts/github-commit-link.coffee
@@ -37,4 +37,4 @@ module.exports = (robot) ->
           url = url.replace(/commits/,'commit')
           msg.send "Commit: " + commt_obj.commit.message + " " + url
     else
-      msg.send "Hey! You need to set HUBOT_GITHUB_REPO and HUBOT_GITHUB_TOKEN first."
+      msg.send "Hey! You need to set HUBOT_GITHUB_REPO and HUBOT_GITHUB_TOKEN before I can link to that commit."


### PR DESCRIPTION
Hubot listens for a given `SHA` and returns the respective github commit page URL.
### example

```
12:56:03 achiu | check out 251a8fb
12:56:04 hubot | Commit: fix a bug https://github.com/achiu/some_repo/commit/251a8fbc8864f90a546058ee9d089b0ecba9b22
```
