### PR TITLE
"SSL Everywhere" for GitHub URLs

### DIFF
--- a/src/scripts/github-activity.coffee
+++ b/src/scripts/github-activity.coffee
@@ -29,7 +29,7 @@ module.exports = (robot) ->
       else if commits.length == 0
           msg.send "Achievement unlocked: [LIKE A BOSS] no commits found!"
       else
-        msg.send "http://github.com/#{repo}"
+        msg.send "https://github.com/#{repo}"
         send = 5
         for c in commits
           if send

--- a/src/scripts/github-commiters.coffee
+++ b/src/scripts/github-commiters.coffee
@@ -42,5 +42,5 @@ module.exports = (robot) ->
         else if commits.length == 0
           msg.send "Achievement unlocked: [LIKE A BOSS] no commits found!"
         else
-          msg.send "http://github.com/#{repo}"
+          msg.send "https://github.com/#{repo}"
           response_handler commits

--- a/src/scripts/github-issue-link.coffee
+++ b/src/scripts/github-issue-link.coffee
@@ -26,4 +26,4 @@ module.exports = (robot) ->
     issue_title = ""
     github.get "https://api.github.com/repos/#{bot_github_repo}/issues/" + issue_number, (issue_obj) ->
       issue_title = issue_obj.title
-      msg.send "Issue " + issue_number + ": " + issue_title  + "  http://github.com/" + bot_github_repo + '/issues/' + issue_number
+      msg.send "Issue " + issue_number + ": " + issue_title  + "  https://github.com/" + bot_github_repo + '/issues/' + issue_number


### PR DESCRIPTION
Since this change, https://github.com/blog/738-sidejack-prevention-phase-2-ssl-everywhere
every call to http://github.com/**/* will cause extra redirect to `s/http/https/`.

This fix reduces the redirects.
