### PR TITLE
Increase SHIPPING power

### DIFF
--- a/src/scripts/shipit.coffee
+++ b/src/scripts/shipit.coffee
@@ -1,11 +1,14 @@
 # Description:
 #   Rodent Motivation
 #
+#   Set the environment variable HUBOT_SHIP_EXTRA_SQUIRRELS (to anything)
+#   for additional motivation
+#
 # Dependencies:
 #   None
 #
 # Configuration:
-#   None
+#   HUBOT_SHIP_EXTRA_SQUIRRELS
 #
 # Commands:
 #   ship it - Display a motivation squirrel
@@ -34,5 +37,12 @@ squirrels = [
 ]
 
 module.exports = (robot) ->
-  robot.hear /ship(ping|z|s|ped)? it/i, (msg) ->
+
+  # Enable a looser regex if environment variable is set
+  if process.env.HUBOT_SHIP_EXTRA_SQUIRRELS
+    regex = /ship(ping|z|s|ped)? it/i
+  else
+    regex = /ship it/i
+
+  robot.hear regex, (msg) ->
     msg.send msg.random squirrels


### PR DESCRIPTION
I often make the fatal mistake of 'shipping it' in IRC, and this makes me sad as I don't receive a motivational squirrel.  This is a minor change to the SHIP IT script's regex to allow it to match other similar phrases. Thereby increasing the number of motivational squirrels that Hubot can supply.

Previously this script matched:
- ship it

Setting the environment variable HUBOT_SHIP_EXTRA_SQUIRRELS with any value, will change to a looser regex which will match the following:
- ship it
- shipping it
- shipped it
- ships it
- shipz it
