### PR TITLE
Plus one

### DIFF
--- a/src/scripts/plus_one.coffee
+++ b/src/scripts/plus_one.coffee
@@ -7,7 +7,7 @@
 module.exports = (robot) ->
   robot.brain.data.achievements ||= {}
 
-  robot.hear /(.*):? *(\+1|thx) for (.*)$/i, (msg) ->
+  robot.hear /(.*): *(\+1|thx) for (.*)$/i, (msg) ->
     receiver = msg.match[1].trim()
     thanking = msg.message.user.name
     reason   = msg.match[3]


### PR DESCRIPTION
Hey,

using this script we can have ranking board on our campfire.
When Michael says thanks to Adam, he says on campfire

```
Adam: thx for helping with CSS for back office panel
```

a plus is stored on Adam's account together with reason.

Always you can ask hubot to show ranking:

```
Hubot show ranking
```

or check who thanks you for what!
