### PR TITLE
Add a GitHub WebHook script.

### DIFF
--- a/src/scripts/github-webhook.coffee
+++ b/src/scripts/github-webhook.coffee
@@ -1,0 +1,30 @@
+# Description:
+#   Announce changes to GitHub repositories using GitHub's webhook service
+#   to a room sepecified by the URL. This has only been tested with the
+#   xmpp service.
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   Enable a 'WebHook URL' under [repo admin] >> Service Hooks. Have it POST
+#   to ${YOURHUBOTURL}:8080/hubot/github/${ROOM_NAME}. More documentation is
+#   available at https://help.github.com/articles/post-receive-hooks .
+#
+# Author:
+#   Steven Merrill, based on bitbucket.coffee by JRusbatch
+
+module.exports = (robot) ->
+  robot.router.post '/hubot/github/:room', (req, res) ->
+    room = req.params.room
+
+    data = JSON.parse req.body.payload
+    commits = data.commits
+
+    msg = "#{commits.length} commits were pushed to #{data.ref} in the '#{data.repository.name}' repository:\n\n"
+    msg += "[#{commit.author.name}] #{commit.message}\n" for commit in commits
+
+    robot.messageRoom room, msg
+
+    res.writeHead 204, { 'Content-Length': 0 }
+    res.end()


### PR DESCRIPTION
In a similar fashion to the bitbucket.coffee script, this script will
allow you to set up a post-receive hook on a GitHub repository and have
the bot notify a room when new commits are pushed.

An example of the output is as follows:

```
3 commits were pushed to refs/heads/master in the 'ourhubot' repository:

[Steven Merrill] Enable test HTTP script.
[Steven Merrill] Add BitBucket commit announcements.
[Steven Merrill] Give our bot a big upgrade.
```
