### PR TITLE
Added Status script to manage user away messages and status messages

### DIFF
--- a/src/scripts/status.coffee
+++ b/src/scripts/status.coffee
@@ -2,7 +2,7 @@
 #   Status is a simple user status message updater
 #
 # Dependencies:
-#   None
+#   "underscore": "1.3.3"
 #
 # Configuration:
 #   None


### PR DESCRIPTION
Status is a great hubot script to help teams communicate by allowing users to set themselves as 'away' with an optional away message. When a user tries to mention an away user, hubot will respond with the user's away message. Users can also set status messages to update people on what they're working on. Finally, you can use 'statuses' to see everyone's status.
