### PR TITLE
Added yell script to mention everyone in the chat room

### DIFF
--- a/src/scripts/yell.coffee
+++ b/src/scripts/yell.coffee
@@ -2,7 +2,7 @@
 #   Allows you to "yell" your message to everyone in the room
 #
 # Dependencies:
-#   None
+#   "underscore": "1.3.3"
 #
 # Configuration:
 #   None


### PR DESCRIPTION
Yell is a simple script to relay your message to all users in the chat room. Most people in our office only look at Campfire if they're mentioned, so it can be cumbersome to ask everyone a question.
