### PR TITLE
Bugfix - handle EC2 instances without tagSets

### DIFF
--- a/src/scripts/aws.coffee
+++ b/src/scripts/aws.coffee
@@ -98,8 +98,8 @@ getRegionInstances = (region, msg) ->
           arch = instance.architecture
           devType = instance.rootDeviceType
 
-          tags = _.flatten [instance.tagSet.item]
-          name = (_.find tags, (t) -> t.key == 'Name').value
+          tags = _.flatten [instance.tagSet?.item ? []]
+          name = (_.find tags, (t) -> t.key == 'Name')?.value ? 'missing'
 
           msg.send "#{prefix} [#{state}] - #{name} / #{type} [#{devType} #{arch}] / #{dnsName} / #{region} / #{id} - started #{launchTime} #{suffix}"
 


### PR DESCRIPTION
Apparently EC2 instances can be created without names?

This should handle instances without metadata / names
