### PR TITLE
Moved output of xkcd alt text (tooltip) below image.

### DIFF
--- a/src/scripts/xkcd.coffee
+++ b/src/scripts/xkcd.coffee
@@ -27,6 +27,4 @@ module.exports = (robot) ->
           msg.send 'Comic not found.'
         else
           object = JSON.parse(body)
-          msg.send object.title
-          msg.send object.img
-          msg.send object.alt
+          msg.send object.title, object.img, object.alt


### PR DESCRIPTION
This might be a matter of preference, but I think the natural and more common xkcd reading order is title->strip->tooltip - reading the tooltip usually isn't (that) funny without the strip context, or might even spoil the fun by giving something away too early.
