### PR TITLE
ReplyGif - Animated Gifs

### DIFF
--- a/src/scripts/replygif.coffee
+++ b/src/scripts/replygif.coffee
@@ -1,0 +1,35 @@
+# Description:
+#   Makes ReplyGif easier to use. See http://replygif.net.
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   http://replygif.net/<id> - Embeds image from ReplyGif with that id.
+#   hubot replygif <keyword> - Embeds random ReplyGif with the keyword.
+#   hubot replygif me <keyword> - Same as `hubot replygif <keyword>`.
+# 
+# Notes:
+#   Thanks to What Cheer (@whatcheer) for providing the keyword lookup app.
+#
+# Author:
+#   sumeetjain
+
+module.exports = (robot) ->
+  # Listen for someone to link to a ReplyGif and reply with the image.
+  robot.hear /.*replygif\.net\/(i\/)?(\d+).*/i, (msg) ->
+    id = msg.match[2]
+    msg.send "http://replygif.net/i/#{id}#.gif"
+    
+  # Listen for a command to look up a ReplyGif by ID.
+  robot.respond /replygif( me)? (\d+)/i, (msg) ->
+    id = msg.match[2]
+    msg.send "http://replygif.net/i/#{id}#.gif"
+    
+  # Listen for a command to look up a ReplyGif by tag.
+  robot.respond /replygif( me)? (\D+)/i, (msg) ->
+    tag = msg.match[2]
+    msg.send "http://apps.whatcheerinc.com/replygif/#{tag}.gif"


### PR DESCRIPTION
Converts links to ReplyGif into an embedded animated gif in Campfire. Also
listens for the `replygif` command and embeds the relevant ReplyGif based on
either a keyword or the ReplyGif ID.
### Examples:

**Hubot is commanded to pull up a ReplyGif; he complies.**
![Listen](http://cl.ly/LIm8/listen.png)

**Hubot hears someone mention ReplyGif, so he courteously embeds the referenced image.**
![Hear](http://cl.ly/LHiD/hear.png)

---

![](http://replygif.net/i/960#.gif)
