### PR TITLE
Ability to add memes while running, also grumpy cat

### DIFF
--- a/src/scripts/meme_generator.coffee
+++ b/src/scripts/meme_generator.coffee
@@ -31,70 +31,107 @@
 #   skalnik
 
 module.exports = (robot) ->
-  robot.respond /Y U NO (.+)/i, (msg) ->
-    caption = msg.match[1] || ""
+  unless robot.brain.data.memes?
+    robot.brain.data.memes = [
+      {
+        regex: /(Y U NO) (.+)/i,
+        generatorID: 2,
+        imageID: 166088
+      },
+      {
+        regex: /(I DON'?T ALWAYS .*) (BUT WHEN I DO,? .*)/i,
+        generatorID: 74,
+        imageID: 2485
+      },
+      {
+        regex: /(.*)(O\s?RLY\??.*)/i,
+        generatorID: 920,
+        imageID: 117049
+      },
+      {
+        regex: /(.*)(SUCCESS|NAILED IT.*)/i,
+        generatorID: 121,
+        imageID: 1031
+      },
+      {
+        regex: /(.*) (ALL the .*)/i,
+        generatorID: 6013,
+        imageID: 1121885
+      },
+      {
+        regex: /(.*) (\w+\sTOO DAMN .*)/i,
+        generatorID: 998,
+        imageID: 203665
+      },
+      {
+        regex: /(GOOD NEWS EVERYONE[,.!]?) (.*)/i,
+        generatorID: 1591,
+        imageID: 112464
+      },
+      {
+        regex: /(NOT SURE IF .*) (OR .*)/i,
+        generatorID: 305,
+        imageID: 84688
+      },
+      {
+        regex: /(YO DAWG .*) (SO .*)/i,
+        generatorID: 79,
+        imageID: 108785
+      },
+      {
+        regex: /(ALL YOUR .*) (ARE BELONG TO US)/i,
+        generatorID: 349058,
+        imageID: 2079825
+      },
+      {
+        regex: /(.*) (FUCK YOU)/i,
+        generatorID: 1189472,
+        imageID: 5044147
+      },
+      {
+        regex: /(.*) (You'?re gonna have a bad time)/i,
+        generatorID: 825296,
+        imageID: 3786537
+      },
+      {
+        regex: /(one does not simply) (.*)/i,
+        generatorID: 274947,
+        imageID: 1865027
+      },
+      {
+        regex: /(grumpy cat) (.*),(.*)/i,
+        generatorID: 1590955,
+        imageID: 6541210
+      }
+    ]
 
-    memeGenerator msg, 2, 166088, "Y U NO", caption, (url) ->
-      msg.send url
+  for meme in robot.brain.data.memes
+    memeResponder robot, meme
 
-  robot.respond /(I DON'?T ALWAYS .*) (BUT WHEN I DO,? .*)/i, (msg) ->
-    memeGenerator msg, 74, 2485, msg.match[1], msg.match[2], (url) ->
-      msg.send url
+  robot.respond /add meme \/(.+)\/i,(.+),(.+)/i, (msg) ->
+    meme =
+      regex: new RegExp(msg.match[1], "i")
+      generatorID: parseInt(msg.match[2])
+      imageID: parseInt(msg.match[3])
 
-  robot.respond /(.*)(O\s?RLY\??.*)/i, (msg) ->
-    memeGenerator msg, 920, 117049, msg.match[1], msg.match[2], (url) ->
-      msg.send url
-
-  robot.respond /(.*)(SUCCESS|NAILED IT.*)/i, (msg) ->
-    memeGenerator msg, 121, 1031, msg.match[1], msg.match[2], (url) ->
-      msg.send url
-
-  robot.respond /(.*) (ALL the .*)/i, (msg) ->
-    memeGenerator msg, 6013, 1121885, msg.match[1], msg.match[2], (url) ->
-      msg.send url
-
-  robot.respond /(.*) (\w+\sTOO DAMN .*)/i, (msg) ->
-    memeGenerator msg, 998, 203665, msg.match[1], msg.match[2], (url) ->
-      msg.send url
-
-  robot.respond /(GOOD NEWS EVERYONE[,.!]?) (.*)/i, (msg) ->
-    memeGenerator msg, 1591, 112464, msg.match[1], msg.match[2], (url) ->
-      msg.send url
+    robot.brain.data.memes.push meme
+    memeResponder robot, meme
 
   robot.respond /k(?:ha|ah)nify (.*)/i, (msg) ->
     memeGenerator msg, 6443, 1123022, "", khanify(msg.match[1]), (url) ->
-      msg.send url
-      
-  robot.respond /(NOT SURE IF .*) (OR .*)/i, (msg) ->
-    memeGenerator msg, 305, 84688, msg.match[1], msg.match[2], (url) ->
-      msg.send url
-
-  robot.respond /(YO DAWG .*) (SO .*)/i, (msg) ->
-    memeGenerator msg, 79, 108785, msg.match[1], msg.match[2], (url) ->
-      msg.send url
-
-  robot.respond /(ALL YOUR .*) (ARE BELONG TO US)/i, (msg) ->
-    memeGenerator msg, 349058, 2079825, msg.match[1], msg.match[2], (url) ->
       msg.send url
 
   robot.respond /(IF .*), ((ARE|CAN|DO|DOES|HOW|IS|MAY|MIGHT|SHOULD|THEN|WHAT|WHEN|WHERE|WHICH|WHO|WHY|WILL|WON\'T|WOULD)[ \'N].*)/i, (msg) ->
     memeGenerator msg, 17, 984, msg.match[1], msg.match[2] + (if msg.match[2].search(/\?$/)==(-1) then '?' else ''), (url) ->
       msg.send url
 
-  robot.respond /(.*) FUCK YOU/i, (msg) ->
-    memeGenerator msg, 1189472, 5044147, msg.match[1], 'FUCK YOU', (url) ->
-      msg.send url
-
   robot.respond /((Oh|You) .*) ((Please|Tell) .*)/i, (msg) ->
     memeGenerator msg, 542616, 2729805, msg.match[1], msg.match[3], (url) ->
       msg.send url
 
-  robot.respond /(.*) (You'?re gonna have a bad time)/i, (msg) ->
-    memeGenerator msg, 825296, 3786537, msg.match[1], msg.match[2], (url) ->
-      msg.send url
-
-  robot.respond /(one does not simply) (.*)/i, (msg) ->
-    memeGenerator msg, 274947, 1865027, msg.match[1], msg.match[2], (url) ->
+memeResponder = (robot, meme) ->
+  robot.respond meme.regex, (msg) ->
+    memeGenerator msg, meme.generatorID, meme.imageID, msg.match[1], msg.match[2], (url) ->
       msg.send url
 
 memeGenerator = (msg, generatorID, imageID, text0, text1, callback) ->


### PR DESCRIPTION
Added the ability to tell hubot to add a new meme from memegenerator while hubot is running.

The new command is `hubot add meme /new meme regex (.*),(.*)/i, 1, 2` with two regex groups for the two lines and where `1` is the generatorID and `2` is the imageID.

I also added grumpy cat.
