### PR TITLE
Add github-status script

### DIFF
--- a/src/scripts/github-status.coffee
+++ b/src/scripts/github-status.coffee
@@ -4,7 +4,6 @@
 # Commands:
 #   hubot github status - Return the current status of Github according to their own Status API.
 
-
 module.exports = (robot) ->
   robot.respond /(github|gh) (status|st)/i, (msg) ->
     githubStatus msg, (status) ->


### PR DESCRIPTION
This script uses the new Status API released a few days ago. It outputs the human-readable string representing the current server status (i.e.: "Everything operating normally").
