### PR TITLE
Added locpix script

### DIFF
--- a/src/scripts/locpix.coffee
+++ b/src/scripts/locpix.coffee
@@ -16,11 +16,10 @@
 module.exports = (robot) ->
   robot.respond /locpix?(?: me)? (.*)/i, (msg) ->
     q = escape(msg.match[1])
-    msg.http('http://www.loc.gov/pictures/search/?fo=json&q=' + q )
+    msg.http('http://www.loc.gov/pictures/search/?fo=json&fa=displayed:anywhere&q=' + q )
       .get() (err, res, body) ->
         response = JSON.parse(body)
         images = response.results
         if images.length > 0
           image  = msg.random images
-          image  = msg.random images while (/500x500_TGM/.test(image.image.full) or /500x500_look/.test(image.image.full) or /500x500_grouprecord/.test(image.image.full) or /500x500_notdigitized/.test(image.image.full))
           msg.send image.image.full


### PR DESCRIPTION
locpix will search the Library of Congress image archives.  Similar to searching google images.   Could deal with some more error checking, but it works.
