### PR TITLE
Update src/scripts/github-commit-link.coffee

### DIFF
--- a/src/scripts/github-commit-link.coffee
+++ b/src/scripts/github-commit-link.coffee
@@ -35,6 +35,6 @@ module.exports = (robot) ->
           url = commit_obj.url.replace(/api\./,'')
           url = url.replace(/repos\//,'')
           url = url.replace(/commits/,'commit')
-          msg.send "Commit: " + commt_obj.commit.message + " " + url
+          msg.send "Commit: " + commit_obj.commit.message + " " + url
     else
       msg.send "Hey! You need to set HUBOT_GITHUB_REPO and HUBOT_GITHUB_TOKEN before I can link to that commit."


### PR DESCRIPTION
Fixed variable name typo.
