### PR TITLE
Better issue matching

### DIFF
--- a/src/scripts/jira-issues.coffee
+++ b/src/scripts/jira-issues.coffee
@@ -6,6 +6,7 @@
 #
 # Configuration:
 #   HUBOT_JIRA_DOMAIN
+#   HUBOT_JIRA_IGNORECASE (optional; default is "true")
 #
 # Commands:
 # 
@@ -26,7 +27,10 @@ module.exports = (robot) ->
       json = JSON.parse(data)
       jiraPrefixes = ( entry.key for entry in json )
       reducedPrefixes = jiraPrefixes.reduce (x,y) -> x + "-|" + y
-      jiraPattern = "/\\b(" + reducedPrefixes + "-)(\\d+)\\b/gi"
+      jiraPattern = "/\\b(" + reducedPrefixes + "-)(\\d+)\\b/g"
+      ic = process.env.HUBOT_JIRA_IGNORECASE
+      if ic == undefined || ic == "true"
+        jiraPattern += "i"
 
       robot.hear eval(jiraPattern), (msg) ->
         for i in msg.match


### PR DESCRIPTION
Finding that this task matches things like product-1.0.0 as PRODUCT-1. It's reasonable to expect that '.' might conclude a ticket such as in the previous sentence, so in that scenario users might want to require issues be types in caps to be more specific that it is an issue.

Also added word boundaries to the match.
