### PR TITLE
Fixing `cheer` script

### DIFF
--- a/src/scripts/cheer.coffee
+++ b/src/scripts/cheer.coffee
@@ -26,6 +26,6 @@ aww = (msg) ->
     .http('http://imgur.com/r/aww.json')
       .get() (err, res, body) ->
         images = JSON.parse(body)
-        images = images.gallery
+        images = images.data
         image  = msg.random images
         msg.send "http://i.imgur.com/#{image.hash}#{image.ext}"


### PR DESCRIPTION
This script was broken due a change at imgur's API json representation. Now the JSON returns the encapsulated images gallery as a `data` element. This error was causing hubot to hang everytime someone tried to use this script
