### PR TITLE
Make me

### DIFF
--- a/src/make_me.coffee
+++ b/src/make_me.coffee
@@ -100,7 +100,10 @@ module.exports = (robot) ->
     if scale_op = /scale by (\d+\.\d+)/.exec(options)
       scale = parseFloat(scale_op[1])
 
-    msg.reply "Talking to the 3d printer to print #{things.length} models '#{options}'..."
+    reply = "Telling the 3D printer to print #{things.length} models"
+    reply += " with the options: #{options}" if options.length > 0
+    msg.reply reply
+
     msg.http(makeServer + "/print")
       .header("Authorization", "Basic #{auth64}")
       .post(JSON.stringify({url: things, count: count, scale: scale, quality: quality, density: density, config: config})) (err, res, body) =>


### PR DESCRIPTION
This adds `make_me.coffee`, the Hubot driver for [make-me/make-me](https://github.com/make-me/make-me)'s HTTP API

It offers `/3d me`

```
Hubot 3d me [STL URLs] [[options]] - prints an STL file
  You can list multiple URLs separated by spaces.

  Options can follow the URL and are:
    '(high|medium|low) quality' -- sets the quality of the print. Default: medium
    'xN' (e.g. x2)              -- print more than one of a thing at once
    'with supports'             -- adds supports to the model, for complex overhangs. Default: disabled
    'xx% solid'                 -- changes how solid the object is on the inside. Default: 5%
    'scale by X.Y' (e.g. 0.5)   -- scale the size of the model by a factor
```

/cc @skalnik
