### PR TITLE
Sends the correct args to build supports and rafts for prints

### DIFF
--- a/src/scripts/make_me.coffee
+++ b/src/scripts/make_me.coffee
@@ -117,8 +117,10 @@ module.exports = (robot) ->
         scale: scale,
         quality: quality,
         density: density,
-        supports: supports,
-        raft: raft
+        slicer_args: {
+          doSupport: supports,
+          doRaft: raft
+        }
       })) (err, res, body) =>
         if res.statusCode is 200
           msg.reply "Your thing is printin'! Check logs at #{makeServer}/log"


### PR DESCRIPTION
Fixes the args passed to https://github.com/make-me/make-me to build a print with supports and rafts.
