### PR TITLE
Prevent @cache from becoming null

### DIFF
--- a/src/scripts/jira.coffee
+++ b/src/scripts/jira.coffee
@@ -31,7 +31,10 @@ class IssueFilters
     @cache = []
 
     @robot.brain.on 'loaded', =>
-      @cache = @robot.brain.data.jqls
+      jqls_from_brain = @robot.brain.data.jqls
+      # only overwrite the cache from redis if data exists in redis
+      if jqls_from_brain
+        @cache = jqls_from_brain
 
   add: (filter) ->
     @cache.push filter


### PR DESCRIPTION
When the jira plugin is loaded for the first time, there is
nothing stored in the brain. This causes @cache to get set to
null which results in errors being thrown during @cache.forEach

Only set the cache to data from the brain if that data exists.
