### PR TITLE
Natural availability tracking with "brb"

### DIFF
--- a/src/scripts/brb.coffee
+++ b/src/scripts/brb.coffee
@@ -1,0 +1,34 @@
+# Description:
+#   Natural availability tracking.
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   brb
+#
+# Author:
+#   jmhobbs
+
+module.exports = (robot) ->
+
+	users_away = {}
+  
+	robot.hear( /./i, (msg) ->
+		if users_away[msg.message.user.name] and msg.message.text != 'brb'
+			msg.send "Welcome back " + msg.message.user.name + "!"
+			delete users_away[msg.message.user.name]
+		else
+			for user, state of users_away
+				substr = msg.message.text.substring(0, user.length+1)
+				if substr == user + ':'
+					msg.send user + " is currently away."
+					break
+		)
+
+	robot.hear /brb/i, (msg) ->
+		users_away[msg.message.user.name] = true
+


### PR DESCRIPTION
My team was previously using availability.coffee, but we found it cumbersome to explicitly tell hubot what we were doing.

Looking at our chat logs, we really only had two states, available and brb.

So now we use this script, which watches for people saying they will brb and marks them as away, then marks them as back whenever they say something in the room again.

```
jmhobbs> brb
   alex> jmhobbs: ಠ_ಠ 
  hubot> jmhobbs is currently away.
jmhobbs> alex: (╯°□°)╯︵ ┻━┻
  hubot> Welcome back jmhobbs!
```
