### PR TITLE
Hey Hubot! Geocode this!

### DIFF
--- a/src/scripts/geocodeme.coffee
+++ b/src/scripts/geocodeme.coffee
@@ -33,5 +33,7 @@ geocodeMe = (msg, query, cb) ->
       })
       .get() (err, res, body) ->
         response = JSON.parse(body)
+        cb "No idea. Tried using a map? https://maps.google.com/" if response.results.length == 0
+
         location = response.results[0].geometry.location.lat + "," + response.results[0].geometry.location.lng
         cb "That's somewhere around " + location + " - https://maps.google.com/maps?q=" + location


### PR DESCRIPTION
I need the lat/lon of random places fairly often, except i'm a little too lazy to open getlatlon.com or drop a lat/lon marker in Google Maps. So I drafted in Hubot to help me out.

```
hubot> hubot where is the tower of london?
hubot> That's somewhere around 51.5072912,-0.0767195 - https://maps.google.com/maps?q=51.5072912,-0.0767195
```

```
hubot> hubot where is Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch?
hubot> That's somewhere around 53.2246219,-4.197995 - https://maps.google.com/maps?q=53.2246219,-4.197995
```

```
hubot> hubot where is cockermouth?
hubot> That's somewhere around 54.663261,-3.367985 - https://maps.google.com/maps?q=54.663261,-3.367985
```

Either `where is` or `geocode me` can be used in phrasing to Hubot. The Google Maps API is used to locate places, so there is a daily per IP limit, but this is fairly high for Hubots usage.
