### PR TITLE
Bump wolfram library to a more stable version

### DIFF
--- a/src/scripts/wolfram.coffee
+++ b/src/scripts/wolfram.coffee
@@ -2,7 +2,7 @@
 #   Allows hubot to answer almost any question by asking Wolfram Alpha
 #
 # Dependencies:
-#   "wolfram": "0.2.0"
+#   "wolfram": "0.2.2"
 #
 # Configuration:
 #   HUBOT_WOLFRAM_APPID - your AppID


### PR DESCRIPTION
Version 0.2.2 of the library fixes some issues that prevent this script from working.

Related issue: strax/wolfram#6
