### PR TITLE
github-commits: support for tags / branches and error handling

### DIFF
--- a/src/scripts/github-commits.coffee
+++ b/src/scripts/github-commits.coffee
@@ -33,10 +33,21 @@ module.exports = (robot) ->
     user.room = query.room if query.room
     user.type = query.type if query.type
 
-    payload = JSON.parse req.body.payload
+    try
+      payload = JSON.parse req.body.payload
 
-    robot.send user, "Got #{payload.commits.length} new commits from #{payload.commits[0].author.name} on #{payload.repository.name}"
-    for commit in payload.commits
-       do (commit) ->
-          gitio commit.url, (err, data) ->
-             robot.send user, "  * #{commit.message} (#{if err then commit.url else data})"
+      if payload.commits.length > 0
+        robot.send user, "Got #{payload.commits.length} new commits from #{payload.commits[0].author.name} on #{payload.repository.name}"
+        for commit in payload.commits
+          do (commit) ->
+            gitio commit.url, (err, data) ->
+              robot.send user, "  * #{commit.message} (#{if err then commit.url else data})"
+      else
+        if payload.created
+          robot.send user, "#{payload.pusher.name} created: #{payload.ref}: #{payload.base_ref}"
+        if payload.deleted
+          robot.send user, "#{payload.pusher.name} deleted: #{payload.ref}"
+
+    catch error
+      console.log "github-commits error: #{error}. Payload: #{req.body.payload}"
+


### PR DESCRIPTION
Previously when someone created or deleted a tag, script would crash. Now it prints:

"username created: refs/tags/some_tag"

And in case of weird payload, error and payload are dumped for future analysis.
