### PR TITLE
jenkins-notifier.coffee: Encode project urls with whitespaces

### DIFF
--- a/src/scripts/jenkins-notifier.coffee
+++ b/src/scripts/jenkins-notifier.coffee
@@ -49,7 +49,7 @@ module.exports = (robot) ->
           if data.name in @failing
             index = @failing.indexOf data.name
             @failing.splice index, 1 if index isnt -1
-            robot.send user, "BUILD RESTORED: #{data.name} ##{data.build.number} (#{data.build.full_url})"
+            robot.send user, "BUILD RESTORED: #{data.name} ##{data.build.number} (#{encodeURI(data.build.full_url)})"
 
     catch error
       console.log "jenkins-notify error: #{error}. Data: #{req.body}"


### PR DESCRIPTION
The project url will be processed with encodeURI() to replace invalid chars

/cc @spajus
