### PR TITLE
YABM (yet another beer me)

### DIFF
--- a/src/scripts/beeradvocate.coffee
+++ b/src/scripts/beeradvocate.coffee
@@ -1,0 +1,29 @@
+# Description:
+# An alternate to the existing beer script, this will scrape beer advocate for the most recent accessed beer.
+# It returns the name of the beer, a picture of the beer and a link to the beer. Hubot is now full of
+# different options for beer scripts. Removing the ? (optional) after (a|advocate) will force the command
+# to be 'beer advocate me' and thereby allow this script to coexist with other beer scripts peacefully.
+#
+# Dependencies:
+# None
+#
+# Configuration:
+# None
+#
+# Commands:
+# beer me - returns the latest beer discussed on beer advocate with picture
+#
+# Author:
+# whyjustin
+
+module.exports = (robot) ->
+    robot.respond /beer (a|advocate)?( me)?/i, (msg) ->
+        msg.http("http://beeradvocate.com/beer/")
+            .get() (err, res, body) ->
+                if (res.statusCode == 200)
+                    reg = /<h6><a href="\/beer\/profile\/(.+?)\/(.+?)">(.+?)<\/a><\/h6>/i
+                    results = body.match(reg)
+                    if (results != null && results.length > 3)
+                        msg.send results[3]
+                        msg.send 'http://beeradvocate.com/beer/profile/' + results[1] + '/' + results[2]
+                        msg.send 'http://beeradvocate.com/im/thumb.php?im=beers/' + results[2] + '.jpg'


### PR DESCRIPTION
Another beer me implementation. This one pulls the most recently discussed beer from beeradvocate.com, the internet's largest and most active beer community. It supplies the name of the beer, a picture of the beer, and link to the beer profile. While the script may be volatile due to Beer Advocates lack of API (it uses regex to scrape), there is lots of room for functionality expansion including returning the beer rating, style, brewer, and ABV. Given the size of the Beer Advocate community, the source data should not stale quickly.
