### PR TITLE
Removes the broken image link from shipit.coffee

### DIFF
--- a/src/scripts/shipit.coffee
+++ b/src/scripts/shipit.coffee
@@ -17,7 +17,6 @@
 #   maddox
 
 squirrels = [
-  "http://img.skitch.com/20100714-d6q52xajfh4cimxr3888yb77ru.jpg",
   "https://img.skitch.com/20111026-r2wsngtu4jftwxmsytdke6arwd.png",
   "http://images.cheezburger.com/completestore/2011/11/2/aa83c0c4-2123-4bd3-8097-966c9461b30c.jpg",
   "http://images.cheezburger.com/completestore/2011/11/2/46e81db3-bead-4e2e-a157-8edd0339192f.jpg",


### PR DESCRIPTION
The [first image](http://img.skitch.com/20100714-d6q52xajfh4cimxr3888yb77ru.jpg) in shipit is a broken link, this changeset removes it.
