### PR TITLE
Improve regexp of destiny script

### DIFF
--- a/src/scripts/destiny.coffee
+++ b/src/scripts/destiny.coffee
@@ -14,7 +14,7 @@
 #   KuiKui
              
 module.exports = (robot) ->
-  robot.respond /is it (\w+) day \?/i, (msg) ->
+  robot.respond /is it (\w+) day ?\?/i, (msg) ->
     action = msg.match[1]
     nbDay = Math.floor(new Date().getTime() / 1000 / 86400)
     actionHash = action.length + action.charCodeAt(0) + action.charCodeAt(action.length - 1)


### PR DESCRIPTION
Before it only mached when having a space at the end, e.g. `is it pizza day ?`,
now the space is optional and it also matches `is it pizza day?`.
