### PR TITLE
Base36 large integer handling correction

### DIFF
--- a/src/scripts/base36.coffee
+++ b/src/scripts/base36.coffee
@@ -2,7 +2,7 @@
 #   Base36 encoding and decoding
 #
 # Dependencies:
-#   None
+#   "big-integer": "https://github.com/peterolson/BigInteger.js"
 #
 # Configuration:
 #   None


### PR DESCRIPTION
I discovered the base36 Hubot script does not handle large integers. I modified it using a library here on github for arbitrary integer precision to correct the issue.

An example is 1179848442347828006, where it should encode to 8yp9d7t9ul2e and decode back to the same number. Base36 fails to decode or encode this number due to the number being larger than 2^53, which is the hard limit for javascript's native integer(actually floating point) representation. 
