### PR TITLE
tell.coffee: Separate rooms, Nickname matching

### DIFF
--- a/src/scripts/tell.coffee
+++ b/src/scripts/tell.coffee
@@ -12,12 +12,12 @@
 #
 # Author:
 #   christianchristensen, lorenzhs, xhochy
- 
+
 module.exports = (robot) ->
    localstorage = {}
    robot.respond /tell ([\w.-]*):? (.*)/i, (msg) ->
      datetime = new Date()
-     username = msg.match[1].toLowerCase()
+     username = msg.match[1]
      room = msg.message.user.room
      tellmessage = username + ": " + msg.message.user.name + " @ " + datetime.toLocaleString() + " said: " + msg.match[2] + "\r\n"
      if not localstorage[room]?
@@ -28,12 +28,13 @@ module.exports = (robot) ->
        localstorage[room][username] = tellmessage
      return
  
+   # When a user enters, check if someone left them a message
    robot.enter (msg) ->
-     # just send the messages if they are available...
-     username = msg.message.user.name.toLowerCase()
+     username = msg.message.user.name
      room = msg.message.user.room
      if localstorage[room]?
        for recipient, message of localstorage[room]
+         # Check if the recipient matches username
          if username.match(new RegExp "^"+recipient, "i")
            tellmessage = localstorage[room][recipient]
            delete localstorage[room][recipient]


### PR DESCRIPTION
Expand tell.coffee to separate rooms from each other. Otherwise, messages could end up in the wrong room or even with the wrong person if different people use the same username in different rooms.

The other new feature is case-insensitive prefix-matching for usernames. Some people use different username suffixes depending on the device they're on, but we still want to be able to tell them stuff as soon as they enter.

Also, send the messages when the user _enters_ the room, not when they _say_ something.

This is basically a merge of [this gist](https://gist.github.com/lorenzhs/5227272).
