### PR TITLE
Fix error with getting all users in github-credentials.coffee

### DIFF
--- a/src/scripts/github-credentials.coffee
+++ b/src/scripts/github-credentials.coffee
@@ -22,7 +22,7 @@ module.exports = (robot) ->
   robot.respond /who do you know(\?)?$/i, (msg) ->
     theReply = "Here is who I know:\n"
 
-    for own key, user of robot.brain.users
+    for own key, user of robot.brain.users()
       if(user.githubLogin)
         theReply += user.name + " is " + user.githubLogin + "\n"
 


### PR DESCRIPTION
Previously this was robot.brain.users which returns null.

This change uses the users() method of @robot.brain. Another 
possible fix is to use `robot.brain.data.users` which directly
accesses the users object.
