### PR TITLE
XKCD bugfixes

### DIFF
--- a/src/scripts/xkcd.coffee
+++ b/src/scripts/xkcd.coffee
@@ -47,5 +47,5 @@ module.exports = (robot) ->
                num = Math.floor((Math.random()*max)+1)
                msg.http("http://xkcd.com/#{num}/info.0.json")
                .get() (err, res, body) ->
-               object = JSON.parse(body)
-               msg.send object.title, object.img, object.alt
+                 object = JSON.parse(body)
+                 msg.send object.title, object.img, object.alt


### PR DESCRIPTION
c623258 - Typo causes the alt text to be omitted when retrieving a specific comic by number
cfd76f4 - Indentation problem causes the "random" comic functionality to always return the most recent comic
