### PR TITLE
s3-brain never gets loaded when brain does not exist

### DIFF
--- a/src/scripts/s3-brain.coffee
+++ b/src/scripts/s3-brain.coffee
@@ -101,6 +101,8 @@ module.exports = (robot) ->
 
     if response && response.buffer
       robot.brain.mergeData JSON.parse(response.buffer.toString())
+    else
+      robot.brain.mergeData {}
 
   robot.brain.on 'loaded', () ->
     loaded = true


### PR DESCRIPTION
If there brain-dump.json file does not exist in the S3 bucket, the loaded event never fires so the brain does not get initialized.  This ensures that after the bucket is loaded and found with no data, the loaded event fires.
