### PR TITLE
Open source @github's Hubot PagerDuty integration

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -9,7 +9,7 @@
 #   hubot pager me as <email> - remember your pager email is <email>
 #   hubot pager me incidents - return the current incidents
 #   hubot pager me note <incident> <content> - add note to incident #<incident> with <content>
-#   hubot pager me notes <incident> <content> - show notes for incident #<incident>
+#   hubot pager me notes <incident> - show notes for incident #<incident>
 #   hubot pager me problems - return all open inicidents
 #   hubot pager me ack <incident> - ack incident #<incident>
 #   hubot pager me resolve <incident> - resolve incident #<incident>


### PR DESCRIPTION
## Usage

`hubot pager help`

```
  /who's on call              # return the username of who's on call

  /pager me page <msg>        # create a new incident

  /pager me 60                # take the pager for 60 minutes

  /pager me incidents         # return the current incidents
  /pager me problems          # return all open inicidents

  /pager me ack 24            # ack incident #24
  /pager me resolve 24        # resolve incident #24
```
## Config

Some environment variables are required:

```
HUBOT_PAGERDUTY_USERNAME
HUBOT_PAGERDUTY_PASSWORD
HUBOT_PAGERDUTY_SUBDOMAIN
HUBOT_PAGERDUTY_APIKEY
HUBOT_PAGERDUTY_SCHEDULE_ID
```
## Caveats

`/pager me 60` assumes your Campfire and PagerDuty usernames are identical.
## Easter Eggs

`major` can be substituted for `pager` in most places. Thank Siri for this one.
