### PR TITLE
Added a newly required User-Agent header to drupalorg.coffee.

### DIFF
--- a/src/scripts/drupalorg.coffee
+++ b/src/scripts/drupalorg.coffee
@@ -62,7 +62,7 @@ module.exports = (robot) ->
     url = msg.match[0]
     return if recentLinks.contains url
     recentLinks.add url
-    msg.http(url).get() (err, res, body) ->
+    msg.http(url).headers('User-Agent': 'hubot').get() (err, res, body) ->
       if err
         console.log "Errors getting url: #{url}"
         return   


### PR DESCRIPTION
Drupal.org recently started to forbid requests that don't have a User-Agent header set which broke the drupalorg.coffee script.

This change simply adds a User-Agent header of "hubot".
