### PR TITLE
[mongo-brain] build generic brain, move mongolabbrain

### DIFF
--- a/src/scripts/mongolab-brain.coffee
+++ b/src/scripts/mongolab-brain.coffee
@@ -1,0 +1,66 @@
+# Description:
+#   Replaces default `redis-brain` with MongoDB one. Useful
+#   to those who wants to have persistence on completely free
+#   Heroku account.
+#
+# Dependencies:
+#   "mongodb": "*"
+#
+# Configuration:
+#   MONGOLAB_URI
+#
+# Commands:
+#   None
+#
+# Author:
+#   juancoen, darvin
+
+MongoClient = require('mongodb').MongoClient
+
+encodeKeys = (obj) ->
+  return obj if typeof obj isnt 'object'
+  for key, value of obj
+    if obj.hasOwnProperty key
+      obj[key.replace(/\./g, ":::")] = encodeKeys(obj[key])
+      delete obj[key] if (key.indexOf(".") > -1)
+  obj
+
+decodeKeys = (obj) ->
+  return obj if typeof obj isnt 'object'
+  for key, value of obj
+    if obj.hasOwnProperty key
+      obj[key.replace(/:::/g, ".")] = encodeKeys(obj[key])
+      delete obj[key] if (key.indexOf(":::") > -1)
+  obj
+
+module.exports = (robot) ->
+  mongoUrl   = process.env.MONGOLAB_URI 
+
+  MongoClient.connect mongoUrl, (err, db) ->
+    if err?
+      throw err
+    else
+      robot.logger.debug "Successfully connected to Mongo"
+
+      db.createCollection 'storage', (err, collection) ->
+        collection.findOne {}, (err, document) ->
+          if err?
+            throw err
+          else if document
+            document = decodeKeys document
+            robot.brain.mergeData document
+
+      robot.brain.on 'save', (data) ->
+        db.collection 'storage', (err, collection) ->
+          # https://github.com/christkv/node-mongodb-native/blob/master/lib/mongodb/collection.js#L373
+          # update(selector, document, options, callback)
+          data = encodeKeys data
+          opts =
+            safe: true
+            upsert: true
+          collection.update data, opts, (err) ->
+            throw err if err?
+
+      robot.brain.on 'close', ->
+        db.close()
+


### PR DESCRIPTION
The "mongo-brain" was really specific to mongolab; moved it to mongolab-brain, and built a generic mongo brain with the latest mongo API. 

Still terribly abuses mongo and dumps the entire brain into a document, but such are the limitations of hubot brain. Could consider using the get/set property events to make this less terrible in the future.
