### PR TITLE
Fixing ambush.coffee annoying error on every hear

### DIFF
--- a/src/scripts/ambush.coffee
+++ b/src/scripts/ambush.coffee
@@ -35,8 +35,7 @@ module.exports = (robot) ->
       msg.send "#{msg.match[1]}? Never heard of 'em"
   
   robot.hear /./i, (msg) ->
-    if (!robot.brain.data.ambushes)
-      return
+    return unless robot.brain.data.ambuses?
     if (ambushes = robot.brain.data.ambushes[msg.message.user.name])
       msg.send "Hey, " + msg.message.user.name + ", while you were out:"
       for ambush in ambushes


### PR DESCRIPTION
This fixes an error on every call to hear, ambush.coffee is erroring if no ambushes are set.
