### PR TITLE
Fix: no minutely available in the response.

### DIFF
--- a/src/scripts/darksky.coffee
+++ b/src/scripts/darksky.coffee
@@ -49,6 +49,6 @@ darkSkyMe = (msg, lat, lng, cb) ->
         return
 
       response = "Currently: #{result.currently.summary} (#{result.currently.temperature}F)"
-      response += "\nNext hour: #{result.minutely.summary}"
-      response += "\nToday: #{result.hourly.summary}"
+      response += "\nNext hour: #{result.hourly.summary}"
+      response += "\nToday: #{result.daily.summary}"
       cb response


### PR DESCRIPTION
Example: https://api.forecast.io/forecast/<api key>/51.14990,4.486660 didn't have a minutely available, so using the hourly and daily.
