### PR TITLE
Support for janky-flow

### DIFF
--- a/src/scripts/janky.coffee
+++ b/src/scripts/janky.coffee
@@ -155,8 +155,9 @@ module.exports = (robot) ->
 
       msg.send response
 
-  robot.respond /ci status$/i, (msg) ->
-    get "", {}, (err, statusCode, body) ->
+  robot.respond /ci status( (\*\/[-_\+\.a-zA-z0-9\/]+))?$/i, (msg) ->
+    path = if msg.match[2] then "/#{msg.match[2]}" else ""
+    get path, {}, (err, statusCode, body) ->
       if statusCode == 200
         msg.send(body)
       else


### PR DESCRIPTION
This supports [janky-flow](/mal/janky-flow).

The janky-flow gem adds support for checking the status of a branch across all repos and exposes it to hubot (useful for git-flow-esque branching strategies). This PR allows hubot to make use of the new endpoint.

Usage:

```
hubot: ci status */development
```
