### PR TITLE
homer script, fix repeated response to robot hearing a specific string

### DIFF
--- a/src/scripts/homer.coffee
+++ b/src/scripts/homer.coffee
@@ -5,7 +5,7 @@
 #   None
 #
 # Configuration:
-#   None
+#   robotUsername = your robot's name to ignore hearing messages from it
 #
 # Commands:
 #   beer - replies with random beer quote
@@ -15,6 +15,7 @@
 #
 # Author:
 #   bhankus
+robotUsername = 'YOUR_ROBOTS_USERNAME'
 
 beerQuotes = [
   "Beer... Now there's a temporary solution.",
@@ -35,12 +36,22 @@ internetQuotes = [
   "The Internet? Is that thing still around?"
 ]
 
+notRobot = (user) ->
+  if user isnt robotUsername then true else false
+
 module.exports = (robot) ->
   robot.hear /beer/i, (msg) ->
-    msg.send msg.random beerQuotes
+    if notRobot(msg.message.user.name)
+      msg.send msg.random beerQuotes
+
   robot.hear /bacon|bagel|barbecue|burger|candy|chocolate|donut|sandwich|breakfast|lunch|dinner|food|grub/i, (msg) ->
-    msg.send "Mmmm... " + msg.match[0]
+    if notRobot(msg.message.user.name)
+      msg.send "Mmmm... " + msg.match[0]
+
   robot.hear /try/i, (msg) ->
-    msg.send msg.random tryQuotes
+    if notRobot(msg.message.user.name)
+      msg.send msg.random tryQuotes
+
   robot.hear /internet/i, (msg) ->  
-    msg.send msg.random internetQuotes
+    if notRobot(msg.message.user.name)
+      msg.send msg.random internetQuotes


### PR DESCRIPTION
When the robot responds after hearing the message `beer`, it generates a message string to the chat window with `beer` in the message also. Because it detects the word `beer`, it will respond again with the string and keep on repeating because it hears the word `beer` repeatedly.

I added a check to see if it's a regular user that is providing the command/key or if it's the robot so as to avoid the repetition.
