### PR TITLE
Update dancing Carlton links

### DIFF
--- a/src/scripts/carlton.coffee
+++ b/src/scripts/carlton.coffee
@@ -15,9 +15,8 @@
 
 carltons = [
   "http://media.tumblr.com/tumblr_lrzrlymUZA1qbliwr.gif",
-  "http://3deadmonkeys.com/gallery3/var/albums/random_stuff/Carlton-Dance-GIF.gif",
+  "http://web.archive.org/web/20121119111926/http://3deadmonkeys.com/gallery3/var/albums/random_stuff/Carlton-Dance-GIF.gif",
   "http://gifsoup.com/webroot/animatedgifs/987761_o.gif",
-  "http://gifsoup.com/view1/1307943/carlton-banks-dance-o.gif",
   "http://s2.favim.com/orig/28/carlton-banks-dance-Favim.com-239179.gif",
   "http://gifsoup.com/webroot/animatedgifs/131815_o.gif"
 ]


### PR DESCRIPTION
3deadmonkeys is dead, so use the web archive.

The removed gifsoup link is a shortened dupe of 987761_o.gif
