### PR TITLE
Handle unset issue status / status name.

### DIFF
--- a/src/scripts/jira.coffee
+++ b/src/scripts/jira.coffee
@@ -147,7 +147,7 @@ module.exports = (robot) ->
               issues.fields.assignee.value.displayName
             else
               "no assignee"
-          status: issues.fields.status.value.name
+          status: issues.fields.status.value?.name?
           fixVersion: ->
             if issues.fields.fixVersions? and issues.fields.fixVersions.value != undefined
               issues.fields.fixVersions.value.map((fixVersion) -> return fixVersion.name).join(", ")


### PR DESCRIPTION
Querying for issues with unset status caused Hubot to fall over.

Example JSON returned: https://gist.github.com/xurizaemon/5522401

For https://github.com/github/hubot-scripts/issues/921
