### PR TITLE
Simple bugfix for 9gag script

### DIFF
--- a/src/scripts/9gag.coffee
+++ b/src/scripts/9gag.coffee
@@ -3,7 +3,7 @@
 #
 # Dependencies:
 #   "htmlparser": "1.7.6"
-#   "soupselect: "0.2.0"
+#   "soupselect": "0.2.0"
 #
 # Configuration:
 #   None


### PR DESCRIPTION
Documentation of dependencies was missing a ". Writing a script for auto installing plugins failed because of this.

I only added the " to the documentation of the script.

Thanks in advance
