### PR TITLE
Simple bugfix for wunderground script

### DIFF
--- a/src/scripts/wunderground.coffee
+++ b/src/scripts/wunderground.coffee
@@ -5,8 +5,7 @@
 #   None
 #
 # Configuration:
-#  HUBOT_WUNDERGROUND_API_KEY Sign up at http://www.wunderground.com/weather/api/.
-#
+#   HUBOT_WUNDERGROUND_API_KEY Sign up at http://www.wunderground.com/weather/api/.
 #
 # Commands:
 #   hubot weather me <location> - short-term forecast


### PR DESCRIPTION
Added the api_key parameter to the documentation of the wunderground script so my hubot-plugin script could automatically install those scripts following the documentation standards.
