### PR TITLE
Make sure inc.trigger_summary_data exists

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -10,7 +10,7 @@
 #   hubot pager me incidents - return the current incidents
 #   hubot pager me note <incident> <content> - add note to incident #<incident> with <content>
 #   hubot pager me notes <incident> - show notes for incident #<incident>
-#   hubot pager me problems - return all open inicidents
+#   hubot pager me problems - return all open incidents
 #   hubot pager me ack <incident> - ack incident #<incident>
 #   hubot pager me resolve <incident> - resolve incident #<incident>
 #


### PR DESCRIPTION
Sometimes an incident can come in without `trigger_summary_data` which causes the subsequent lines to fail.
