### PR TITLE
Make `ambush` username matching non-greedy

### DIFF
--- a/src/scripts/ambush.coffee
+++ b/src/scripts/ambush.coffee
@@ -22,7 +22,7 @@ module.exports = (robot) ->
   robot.brain.on 'loaded', =>
     robot.brain.data.ambushes ||= {}
 
-  robot.respond /ambush (.*): (.*)/i, (msg) ->
+  robot.respond /ambush (.*?): (.*)/i, (msg) ->
     users = robot.brain.usersForFuzzyName(msg.match[1].trim())
     if users.length is 1
       user = users[0]


### PR DESCRIPTION
Previously messages such as this one would not work:

```
ambush Benjie: Hey did you see this link: http://example.com/
```

because the script would think the username was: `Benjie: Hey did you see this link` rather than `Benjie` as expected.

This single-character change matches the first ": " rather than the last, thereby solving this problem.

(Only breakage would be for users who have ": " in their username, which seems more of an edge case than having ": " in the message body.)
