### PR TITLE
Specify underscore & underscore.string dependencies

### DIFF
--- a/src/scripts/wikipedia.coffee
+++ b/src/scripts/wikipedia.coffee
@@ -23,14 +23,14 @@ HTMLParser = require "htmlparser"
 
 module.exports = (robot) ->
   robot.respond /(wiki)( me)? (.*)/i, (msg) ->
-    wikiMe msg, msg.match[3], (text, url) ->
+    wikiMe robot, msg.match[3], (text, url) ->
       msg.send text
       msg.send url if url
 
-wikiMe = (msg, query, cb) ->
+wikiMe = (robot, query, cb) ->
   articleURL = makeArticleURL(makeTitleFromQuery(query))
 
-  msg.http(articleURL)
+  robot.http(articleURL)
     .header('User-Agent', 'Hubot Wikipedia Script')
     .get() (err, res, body) ->
       return cb "Sorry, the tubes are broken." if err


### PR DESCRIPTION
The versions are based on the latest compatible version that underscore.string supports.
