### PR TITLE
Specify underscore as a dependency, remove optional configuration

### DIFF
--- a/src/scripts/http-info.coffee
+++ b/src/scripts/http-info.coffee
@@ -3,10 +3,9 @@
 #
 # Dependencies:
 #   "jsdom": "0.2.15"
+#   "underscore": "1.3.3"
 #
 # Configuration:
-#
-# Optional Configuration:
 #   HUBOT_HTTP_INFO_IGNORE_URLS - RegEx used to exclude Urls
 #   HUBOT_HTTP_INFO_IGNORE_USERS - Comma separated list of users to ignore
 #


### PR DESCRIPTION
It's assumed that if you don't specify any URLs to ignore or Users to ignore then it'll accept everything. Also, the parser for the script catalog doesn't support the "Optional Configuration" section so this doesn't appear on the site.
