### PR TITLE
Graylog message fetcher

### DIFF
--- a/src/scripts/graylog.coffee
+++ b/src/scripts/graylog.coffee
@@ -17,6 +17,9 @@
 #   hubot graylog <stream> <count> - output some messages from given stream
 #   hubot graylog host <host> <count> - output some messages from given host
 #
+# Notes
+#   Output format: "[timestamp] message content"
+#
 # Author:
 #   spajus
 


### PR DESCRIPTION
Usage:

```
hubot graylog - output last 5 graylog messages
hubot graylog <count> - output last <count> graylog messages
hubot graylog <stream> <count> - output some messages from given stream
hubot graylog host <host> <count> - output some messages from given host
hubot graylog hosts - list graylog hosts
hubot graylog streams - list graylog streams
```

Example output:

```
Hubot> hubot graylog errors 3
Hubot> [2013-05-22 02-31-39] RestClient::InternalServerError: 500 Internal Server Error
Hubot> [2013-05-22 02-31-39] RestClient::InternalServerError: 500 Internal Server Error
Hubot> [2013-05-22 02-31-37] Errno::ENOENT: No such file or directory - ./public/photos/thumb500_36723.JPG
```
