### PR TITLE
Bug fix in the github-issue-link

### DIFF
--- a/src/scripts/github-issue-link.coffee
+++ b/src/scripts/github-issue-link.coffee
@@ -24,7 +24,7 @@
 
 module.exports = (robot) ->
   github = require("githubot")(robot)
-  robot.hear /.*( (\S*)?#(\d+)).*/, (msg) ->
+  robot.hear /((\S*|^)?#(\d+)).*/, (msg) ->
     issue_number = msg.match[3]
     if isNaN(issue_number)
       return


### PR DESCRIPTION
The bot was hearing for "something repo#nnn" but not for "repo#nnn"
