### PR TITLE
Add ability for jira-issue to ignore posts from certain users.

### DIFF
--- a/src/scripts/jira-issues.coffee
+++ b/src/scripts/jira-issues.coffee
@@ -47,40 +47,41 @@ module.exports = (robot) ->
         jiraPattern += "i"
 
       robot.hear eval(jiraPattern), (msg) ->
-        if not msg.message.user.name.match(new RegExp(jiraIgnoreUsers, "gi"))
-          for i in msg.match
-            issue = i.toUpperCase()
-            now = new Date().getTime()
-            if cache.length > 0
-              cache.shift() until cache.length is 0 or cache[0].expires >= now
-            if cache.length == 0 or (item for item in cache when item.issue is issue).length == 0
-              cache.push({issue: issue, expires: now + 120000})
-              msg.http(jiraUrl + "/rest/api/2/issue/" + issue)
-                .auth(auth)
-                .get() (err, res, body) ->
+        return if msg.message.user.name.match(new RegExp(jiraIgnoreUsers, "gi"))
+
+        for i in msg.match
+          issue = i.toUpperCase()
+          now = new Date().getTime()
+          if cache.length > 0
+            cache.shift() until cache.length is 0 or cache[0].expires >= now
+          if cache.length == 0 or (item for item in cache when item.issue is issue).length == 0
+            cache.push({issue: issue, expires: now + 120000})
+            msg.http(jiraUrl + "/rest/api/2/issue/" + issue)
+              .auth(auth)
+              .get() (err, res, body) ->
+                try
+                  json = JSON.parse(body)
+                  key = json.key
+
+                  message = "[" + key + "] " + json.fields.summary
+                  message += '\nStatus: '+json.fields.status.name
+                  if (json.fields.assignee and json.fields.assignee.displayName)
+                    message += ', assigned to ' + json.fields.assignee.displayName
+                  else
+                    message += ', unassigned'
+                  message += ", rep. by "+json.fields.reporter.displayName
+                  if json.fields.fixVersions and json.fields.fixVersions.length > 0
+                    message += ', fixVersion: '+json.fields.fixVersions[0].name
+                  else
+                    message += ', fixVersion: NONE'
+
+                  msg.send message
+
+                  urlRegex = new RegExp(jiraUrl + "[^\\s]*" + key)
+                  if not msg.message.text.match(urlRegex)
+                    msg.send jiraUrl + "/browse/" + key
+                catch error
                   try
-                    json = JSON.parse(body)
-                    key = json.key
-
-                    message = "[" + key + "] " + json.fields.summary
-                    message += '\nStatus: '+json.fields.status.name
-                    if (json.fields.assignee and json.fields.assignee.displayName)
-                      message += ', assigned to ' + json.fields.assignee.displayName
-                    else
-                      message += ', unassigned'
-                    message += ", rep. by "+json.fields.reporter.displayName
-                    if json.fields.fixVersions and json.fields.fixVersions.length > 0
-                      message += ', fixVersion: '+json.fields.fixVersions[0].name
-                    else
-                      message += ', fixVersion: NONE'
-
-                    msg.send message
-
-                    urlRegex = new RegExp(jiraUrl + "[^\\s]*" + key)
-                    if not msg.message.text.match(urlRegex)
-                      msg.send jiraUrl + "/browse/" + key
-                  catch error
-                    try
-                      msg.send "[*ERROR*] " + json.errorMessages[0]
-                    catch reallyError
-                      msg.send "[*ERROR*] " + reallyError
+                    msg.send "[*ERROR*] " + json.errorMessages[0]
+                  catch reallyError
+                    msg.send "[*ERROR*] " + reallyError


### PR DESCRIPTION
Here is a fix for https://github.com/github/hubot-scripts/issues/960

I introduced a new environment variable HUBOT_JIRA_IGNORE_USERS, which defaults to "jira|github". This means by default the script will ignore references to JIRA tickets by the GitHub and JIRA users. 

In our use-case, this is used to ignore the GitHub and JIRA Hipchat connectors, but I assume this is applicable to other chat systems (IRC, Campfire, etc) as well.
