### PR TITLE
Update time script to allow api url customisation

### DIFF
--- a/src/scripts/time.coffee
+++ b/src/scripts/time.coffee
@@ -31,6 +31,7 @@ module.exports = (robot) ->
       return
     unless process.env.HUBOT_WWO_API_URL
       msg.send 'Please, set HUBOT_WWO_API_URL environment variable'
+      return
     msg.http(process.env.HUBOT_WWO_API_URL)
       .query({
         q: msg.match[1]


### PR DESCRIPTION
The url for the WWO api depends on which plan you have, paid vs free. The url can now be set using env variables.
