### PR TITLE
Twitter Search script

### DIFF
--- a/src/scripts/twitter_mention.coffee
+++ b/src/scripts/twitter_mention.coffee
@@ -30,6 +30,10 @@ module.exports = (robot) ->
 
   key = process.env.HUBOT_TWITTER_CONSUMER_KEY
   secret = process.env.HUBOT_TWITTER_CONSUMER_SECRET
+  if not key or not secret
+    console.log "twitter_mention.coffee: HUBOT_TWITTER_CONSUMER_KEY and HUBOT_TWITTER_CONSUMER_SECRET are required. Get your tokens here: https://dev.twitter.com/apps"
+    return
+
   twitterauth = new oauth.OAuth2(key, secret, "https://api.twitter.com/", null, "oauth2/token", null)
 
   twitterauth.getOAuthAccessToken "", {grant_type:"client_credentials"}, (e, access_token, refresh_token, results) ->


### PR DESCRIPTION
This removes the now defunct twitter_mention.coffee script, given that Twitter [turned off the API today](https://dev.twitter.com/calendar).

Replacing it is a twitter_search.coffee script that uses oAuth against the current 1.1 version of the API. It uses a Bearer token for app-only authentication and also now includes the full tweet text in the room message. 

Also, it incidentally works with the [hipchat](/hipchat/hubot-hipchat) adapter, as the previous script caused an error condition. 
