### PR TITLE
Fix manatee detection

### DIFF
--- a/src/scripts/calm-down.coffee
+++ b/src/scripts/calm-down.coffee
@@ -21,6 +21,6 @@ module.exports = (robot) ->
 
   unless process.env.HUBOT_LESS_MANATEES
     robot.hear ///
-      (([A-Z]{2,}\s+)([A-Z]{2,})\s?)|
-      ([A-Z]{5,})
+      (\b([A-Z]{2,}\s+)([A-Z]{2,})\b)|
+      (\b[A-Z]{5,}\b)
     ///, (msg) -> msg.send manatee()


### PR DESCRIPTION
Adds word boundaries to the yelling regexp. This ensures that it will only detect fully-yelled words and not falsely fire on things like Amazon links.

/cc @camacho
