### PR TITLE
Add option to exclude descriptions from http-info script

### DIFF
--- a/src/scripts/http-info.coffee
+++ b/src/scripts/http-info.coffee
@@ -8,8 +8,7 @@
 # Configuration:
 #   HUBOT_HTTP_INFO_IGNORE_URLS - RegEx used to exclude Urls
 #   HUBOT_HTTP_INFO_IGNORE_USERS - Comma-separated list of users to ignore
-#   HUBOT_HTTP_INFO_IGNORE_DESC - Optional boolean indicating whether a site's 
-#     meta description should be ignored, thus returning only a title
+#   HUBOT_HTTP_INFO_IGNORE_DESC - Optional boolean indicating whether a site's meta description should be ignored
 #
 # Commands:
 #   http(s)://<site> - prints the title and meta description for sites linked.


### PR DESCRIPTION
Meta descriptions can be long. This adds a flag to optionally exclude them.
