### PR TITLE
Updated twitter.coffee for v1.1

### DIFF
--- a/src/scripts/twitter.coffee
+++ b/src/scripts/twitter.coffee
@@ -2,24 +2,59 @@
 #   gets tweet from user
 #
 # Dependencies:
-#   None
+#   "twit": "1.1.6"
+#   "underscore": "1.4.4"
 #
 # Configuration:
-#   None
+#   HUBOT_TWITTER_CONSUMER_KEY
+#   HUBOT_TWITTER_CONSUMER_SECRET
+#   HUBOT_TWITTER_ACCESS_TOKEN
+#   HUBOT_TWITTER_ACCESS_TOKEN_SECRET
 #
 # Commands:
 #   hubot twitter <twitter username> - Show last tweet from <twitter username>
+#   hubot twitter <twitter username> <n> - Cycle through tweet with <n> starting w/ latest
 #
 # Author:
 #   KevinTraver
 #
+
+_ = require "underscore"
+Twit = require "twit"
+config =
+  consumer_key: process.env.HUBOT_TWITTER_CONSUMER_KEY
+  consumer_secret: process.env.HUBOT_TWITTER_CONSUMER_SECRET
+  access_token: process.env.HUBOT_TWITTER_ACCESS_TOKEN
+  access_token_secret: process.env.HUBOT_TWITTER_ACCESS_TOKEN_SECRET
+
 module.exports = (robot) ->
-  robot.respond /(twitter|lasttweet) (.+)$/i, (msg) ->
-   username = msg.match[2]
-   msg.http("http://api.twitter.com/1/statuses/user_timeline/#{escape(username)}.json?count=1&include_rts=true")
-    .get() (err, res, body) ->
-      response = JSON.parse body
-      if response[0]
-       msg.send response[0]["text"]
-      else
-       msg.send "Error"
+  twit = undefined
+
+  robot.respond /(twitter|lasttweet)\s+(\S+)\s?(\d?)/i, (msg) ->
+    unless config.consumer_key
+      msg.send "Please set the HUBOT_TWITTER_STREAM_CONSUMER_KEY environment variable."
+      return
+    unless config.consumer_secret
+      msg.send "Please set the HUBOT_TWITTER_STREAM_CONSUMER_SECRET environment variable."
+      return
+    unless config.access_token
+      msg.send "Please set the HUBOT_TWITTER_STREAM_ACCESS_TOKEN environment variable."
+      return
+    unless config.access_token_secret
+      msg.send "Please set the HUBOT_TWITTER_ACCESS_TOKEN_SECRET environment variable."
+      return
+
+    unless twit
+      twit = new Twit config
+
+    username = msg.match[2]
+    if msg.match[3] then count = msg.match[3] else count = 1
+
+    twit.get "statuses/user_timeline",
+      screen_name: escape(username)
+      count: count
+      include_rts: false
+      exclude_replies: true
+    , (err, reply) ->
+      return msg.send "Error" if err
+      return msg.send _.unescape(_.last(reply)['text']) if reply[0]['text']


### PR DESCRIPTION
Twitter retired v1 of their API this week. v1.1 requires oauth, so I'm leveraging the [twit client](https://github.com/ttezel/twit) to fix the twitter.coffee script.
