### PR TITLE
Feature/Config Redis Brain AutoSave

### DIFF
--- a/src/scripts/redis-brain.coffee
+++ b/src/scripts/redis-brain.coffee
@@ -50,7 +50,7 @@ module.exports = (robot) ->
         robot.brain.setAutoSave true
 
         # Set autosave interval if supplied by config
-        if autoSaveInterval
+        if parseInt(autoSaveInterval) != 'NaN'
           robot.logger.info "Setting brain auto-saving interval to " + autoSaveInterval + "s"
           robot.brain.resetSaveInterval parseInt autoSaveInterval
 


### PR DESCRIPTION
I've added configurable auto saving to the redis brain script. 
It uses:
HUBOT_BRAIN_AUTOSAVE=[true|false]
HUBOT_BRAIN_AUTOSAVE_INTERVAL=<seconds>

Let me know it there is anything out of place with my changes.

Also, if this type of feature is not needed/wanted; I do apologize for the bother.
