### PR TITLE
Update twitter-content with v1.1 compatible API

### DIFF
--- a/src/scripts/tweet-content.coffee
+++ b/src/scripts/tweet-content.coffee
@@ -10,6 +10,9 @@
 #   HUBOT_TWITTER_ACCESS_TOKEN_KEY
 #   HUBOT_TWITTER_ACCES_TOKEN_SECRET
 #
+# Dependencies:
+#  "ntwitter" : "0.2.10",
+#
 # Commands:
 #   None
 #


### PR DESCRIPTION
I wanted to fix this before Campfire did... but didn't. Regardless, this now uses ntwitter and a specified `rest_base` path to avoid forcing an ntwitter upgrade.

But now, you'll have mentions that work again.
