### PR TITLE
Fix tweet.coffee for v1.1 API

### DIFF
--- a/src/scripts/tweet.coffee
+++ b/src/scripts/tweet.coffee
@@ -2,27 +2,68 @@
 #   Display a random tweet from twitter about a subject
 #
 # Dependencies:
-#   None
+#    "ntwitter" : "https://github.com/sebhildebrandt/ntwitter/tarball/master",
 #
 # Configuration:
-#   None
+#   HUBOT_TWITTER_CONSUMER_KEY
+#   HUBOT_TWITTER_CONSUMER_SECRET
+#   HUBOT_TWITTER_ACCESS_TOKEN_KEY
+#   HUBOT_TWITTER_ACCESS_TOKEN_SECRET
 #
 # Commands:
 #   hubot <keyword> tweet - Returns a link to a tweet about <keyword>
 #
+# Notes:
+#   There's an outstanding issue on AvianFlu/ntwitter#110 for search and the v1.1 API.
+#   sebhildebrandt is a fork that is working, so we recommend that for now. This 
+#   can be removed after the issue is fixed and a new release cut, along with updating the dependency
+#
 # Author:
-#   atmos
+#   atmos, technicalpickles
+
+ntwitter = require 'ntwitter'
+inspect = require('util').inspect
 
 module.exports = (robot) ->
-  robot.respond /(.*) tweet/i, (msg) ->
-    search = escape(msg.match[1])
-    msg.http('http://search.twitter.com/search.json')
-      .query(q: search)
-      .get() (err, res, body) ->
-        tweets = JSON.parse(body)
+  auth =
+    consumer_key: process.env.HUBOT_TWITTER_CONSUMER_KEY
+    consumer_secret: process.env.HUBOT_TWITTER_CONSUMER_SECRET
+    access_token_key: process.env.HUBOT_TWITTER_ACCESS_TOKEN_KEY
+    access_token_secret: process.env.HUBOT_TWITTER_ACCESS_TOKEN_SECRET
 
-        if tweets.results? and tweets.results.length > 0
-          tweet  = msg.random tweets.results
-          msg.send "http://twitter.com/#!/#{tweet.from_user}/status/#{tweet.id_str}"
+  twit = undefined
+
+  robot.respond /(.*) tweet/i, (msg) ->
+    unless auth.consumer_key
+      msg.send "Please set the HUBOT_TWITTER_CONSUMER_KEY environment variable."
+      return
+    unless auth.consumer_secret
+      msg.send "Please set the HUBOT_TWITTER_CONSUMER_SECRET environment variable."
+      return
+    unless auth.access_token_key
+      msg.send "Please set the HUBOT_TWITTER_ACCESS_TOKEN_KEY environment variable."
+      return
+    unless auth.access_token_secret
+      msg.send "Please set the HUBOT_TWITTER_ACCESS_TOKEN_SECRET environment variable."
+      return
+
+
+    twit ?= new ntwitter auth
+
+
+    twit.verifyCredentials (err, data) ->
+      if err
+        msg.send "Encountered a problem verifing twitter credentials:(", inspect err
+        return
+
+      q = escape(msg.match[1])
+      twit.search q, (err, data) ->
+        if err
+          msg.send "Encountered a problem twitter searching :(", inspect err
+          return
+
+        if data.statuses? and data.statuses.length > 0
+          status = msg.random data.statuses
+          msg.send "http://twitter.com/#!/#{status.user.screen_name}/status/#{status.id_str}"
         else
           msg.reply "No one is tweeting about that."


### PR DESCRIPTION
After the API retirement, this stopped working. This updates it to use
the ntwitter package, and follows the same configuration conventions as
tweet-mention.coffee for re-use.

It does depend on a fork of ntwitter though, and will need to be so
until AvianFlu/ntwitter#110 is fixed
