### PR TITLE
[pagerduty] print the created_on field when formatting incidents

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -278,11 +278,11 @@ module.exports = (robot) ->
      #   HOSTSTATE: 'UP' },
     if inc.incident_number && inc.trigger_summary_data
       if inc.trigger_summary_data.description
-        "#{inc.incident_number}: #{inc.trigger_summary_data.description} - assigned to #{inc.assigned_to_user.name}\n"
+        "#{inc.incident_number}: #{inc.created_on} #{inc.trigger_summary_data.description} - assigned to #{inc.assigned_to_user.name}\n"
       else if inc.trigger_summary_data.pd_nagios_object == 'service'
-         "#{inc.incident_number}: #{inc.trigger_summary_data.HOSTNAME}/#{inc.trigger_summary_data.SERVICEDESC} - assigned to #{inc.assigned_to_user.name}\n"
+         "#{inc.incident_number}: #{inc.created_on} #{inc.trigger_summary_data.HOSTNAME}/#{inc.trigger_summary_data.SERVICEDESC} - assigned to #{inc.assigned_to_user.name}\n"
       else if inc.trigger_summary_data.pd_nagios_object == 'host'
-         "#{inc.incident_number}: #{inc.trigger_summary_data.HOSTNAME}/#{inc.trigger_summary_data.HOSTSTATE} - assigned to #{inc.assigned_to_user.name}\n"
+         "#{inc.incident_number}: #{inc.created_on} #{inc.trigger_summary_data.HOSTNAME}/#{inc.trigger_summary_data.HOSTSTATE} - assigned to #{inc.assigned_to_user.name}\n"
     else
       ""
 


### PR DESCRIPTION
We thought it would be cool to print when the incidents were created in case a service is flapping.

The docs page says this is super easy, http://developer.pagerduty.com/documentation/rest/incidents/show

I didn't have a good way to test this, but the change is pretty minor.

/cc @technicalpickles 
