### PR TITLE
Github pull request notifier: say who was mentioned

### DIFF
--- a/src/scripts/github-pull-request-notifier.coffee
+++ b/src/scripts/github-pull-request-notifier.coffee
@@ -46,7 +46,7 @@ module.exports = (robot) ->
 
 announcePullRequest = (data, cb) ->
   if data.action == 'opened'
-    mentioned = data.pull_request.body.match(/(^|\s)(@\w+)/g)
+    mentioned = data.pull_request.body.match(/(^|\s)(@[\w\-]+)/g)
 
     if mentioned
       unique = (array) ->


### PR DESCRIPTION
If pull request body contains "@nick1 @nick2", hubot adds "Mentioned: @nick1, @nick2" to the announcement.
