### PR TITLE
New Relic Request to wrong URL

### DIFF
--- a/src/scripts/newrelic.coffee
+++ b/src/scripts/newrelic.coffee
@@ -29,7 +29,7 @@ module.exports = (robot) ->
     apiKey    = process.env.HUBOT_NEWRELIC_API_KEY
     Parser = require("xml2js").Parser
     
-    msg.http("https://rpm.newrelic.com/accounts/#{accountId}/applications/#{appId}/threshold_values.xml?api_key=#{apiKey}")
+    msg.http("https://rpm.newrelic.com/accounts/#{accountId}/applications/#{appId}/threshold_values?api_key=#{apiKey}")
       .get() (err, res, body) ->
         if err
           msg.send "New Relic says: #{err}"


### PR DESCRIPTION
Dropped the `.xml` from the New Relic request URL, it no longer seems to be supported.
