### PR TITLE
Make redis-brain play nicely with a boxen'd redis

### DIFF
--- a/src/scripts/redis-brain.coffee
+++ b/src/scripts/redis-brain.coffee
@@ -18,7 +18,7 @@ Redis = require "redis"
 
 # sets up hooks to persist the brain into redis.
 module.exports = (robot) ->
-  info   = Url.parse process.env.REDISTOGO_URL || 'redis://localhost:6379'
+  info   = Url.parse process.env.REDISTOGO_URL || process.env.BOXEN_REDIS_URL || 'redis://localhost:6379'
   client = Redis.createClient(info.port, info.hostname)
 
   if info.auth


### PR DESCRIPTION
Allows for redis-brain to connect to the local redis on a boxen non-standard port. Needed this for some local development where I had redis running on 16379 via boxen.
