### PR TITLE
Github issues now advises githubot 0.4.0 in order to add a user-agent

### DIFF
--- a/src/scripts/github-issues.coffee
+++ b/src/scripts/github-issues.coffee
@@ -4,7 +4,7 @@
 # Dependencies:
 #   "underscore": "1.3.3"
 #   "underscore.string": "2.1.1"
-#   "githubot": "0.2.0"
+#   "githubot": "0.4.0"
 #
 # Configuration:
 #   HUBOT_GITHUB_TOKEN


### PR DESCRIPTION
v3 of the API refuses connections unless you have a user agent, version 0.4.0 supports this, 0.2.0 doesn't.
