### PR TITLE
URL encode the query string so 'weather %' doesn't crash hubot

### DIFF
--- a/src/scripts/wunderground.coffee
+++ b/src/scripts/wunderground.coffee
@@ -55,7 +55,7 @@ get_data = (robot, msg, location, service, query, cb, lifetime, stack=0) ->
       return
     # get new data
     msg
-      .http("http://api.wunderground.com/api/#{process.env.HUBOT_WUNDERGROUND_API_KEY}/#{service}/q/#{query}.json")
+      .http("http://api.wunderground.com/api/#{process.env.HUBOT_WUNDERGROUND_API_KEY}/#{service}/q/#{encodeURIComponent query}.json")
       .get() (err, res, body) ->
         # check for a non-200 response. cache it for some short amount of time && msg.send 'unavailable'
         data = JSON.parse(body)


### PR DESCRIPTION
URI-encode the parameter so hubot doesn't break so much.
