### PR TITLE
Fix bare phrases in calm-down

### DIFF
--- a/src/scripts/calm-down.coffee
+++ b/src/scripts/calm-down.coffee
@@ -16,11 +16,8 @@ module.exports = (robot) ->
 
   robot.respond /manatee|calm( me)?/i, (msg) -> msg.send manatee()
 
-  robot.hear ///
-    (calm down)|
-    (simmer down)|
-    (that escalated quickly)
-  ///i, (msg) -> msg.send manatee()
+  robot.hear /calm down|simmer down|that escalated quickly/i, (msg) ->
+    msg.send manatee()
 
   unless process.env.HUBOT_LESS_MANATEES
     robot.hear ///


### PR DESCRIPTION
Coffeescript's block regex syntax ignores whitespace, so recognizing whitespace in a phrase would require `\s`.  But I just converted it to one line.
