### PR TITLE
fix infinite loop in bang-bang

### DIFF
--- a/src/scripts/bang-bang.coffee
+++ b/src/scripts/bang-bang.coffee
@@ -17,7 +17,7 @@ module.exports = (robot) ->
   robot.respond /(.+)/i, (msg) ->
     store msg
 
-  robot.respond /!!/i, (msg) ->
+  robot.respond /!!$/i, (msg) ->
 
     if exports.last_command?
       msg.send exports.last_command


### PR DESCRIPTION
If you say "hubot !!!", you can cause bang-bang.coffee to go into an
infinite loop. This is because:
1. The filtering only removes entries that are exactly "!!"
2. The `respond` will match anything that starts with "!!"

Thus, hubot will go into an infinite loop like so:

```
user: hubot !!!
hubot: !!!
hubot: !!!
hubot: !!!
hubot: !!!
...
```
