### PR TITLE
Reply to the original message when reminding

### DIFF
--- a/src/scripts/remind.coffee
+++ b/src/scripts/remind.coffee
@@ -42,12 +42,12 @@ class Reminders
       if @cache.length > 0
         trigger = =>
           reminder = @removeFirst()
-          @robot.send reminder.for, reminder.for.name + ', you asked me to remind you to ' + reminder.action
+          @robot.reply reminder.msg_envelope, 'you asked me to remind you to ' + reminder.action
           @queue()
         @current_timeout = setTimeout trigger, @cache[0].due - now
 
 class Reminder
-  constructor: (@for, @time, @action) ->
+  constructor: (@msg_envelope, @time, @action) ->
     @time.replace(/^\s+|\s+$/g, '')
 
     periods =
@@ -86,6 +86,6 @@ module.exports = (robot) ->
   robot.respond /remind me in ((?:(?:\d+) (?:weeks?|days?|hours?|hrs?|minutes?|mins?|seconds?|secs?)[ ,]*(?:and)? +)+)to (.*)/i, (msg) ->
     time = msg.match[1]
     action = msg.match[2]
-    reminder = new Reminder msg.message.user, time, action
+    reminder = new Reminder msg.envelope, time, action
     reminders.add reminder
     msg.send 'I\'ll remind you to ' + action + ' on ' + reminder.dueDate()


### PR DESCRIPTION
Rather than sending a new message with the name of the person who
requested the reminder, reply to the original message. This will ensure
appropriate @-style replies in, e.g., hipchat.
