### PR TITLE
Fix graylog script - Hubot should respond, not hear

### DIFF
--- a/src/scripts/graylog.coffee
+++ b/src/scripts/graylog.coffee
@@ -25,31 +25,31 @@
 
 module.exports = (robot) ->
 
-  robot.hear /graylog streams$/i, (msg) ->
+  robot.respond /graylog streams$/i, (msg) ->
     graylogStreams msg, (what) ->
       msg.send what
 
-  robot.hear /graylog hosts$/i, (msg) ->
+  robot.respond /graylog hosts$/i, (msg) ->
     graylogHosts msg, (what) ->
       msg.send what
 
-  robot.hear /graylog$/i, (msg) ->
+  robot.respond /graylog$/i, (msg) ->
     graylogStreamMessages msg, 'all', 5, (what) ->
       msg.send what
 
-  robot.hear /graylog (\d+)$/i, (msg) ->
+  robot.respond /graylog (\d+)$/i, (msg) ->
     count = parseInt(msg.match[1] || '5')
     graylogMessages msg, 'messages.json', (messages) ->
       sayMessages messages, count, (what) ->
         msg.send what
 
-  robot.hear /graylog (.+) (\d+)/i, (msg) ->
+  robot.respond /graylog (.+) (\d+)/i, (msg) ->
     stream = msg.match[1]
     count = parseInt(msg.match[2] || '5')
     graylogStreamMessages msg, stream, count, (what) ->
       msg.send what
 
-  robot.hear /graylog host (.+) (\d+)/i, (msg) ->
+  robot.respond /graylog host (.+) (\d+)/i, (msg) ->
     host = msg.match[1]
     count = parseInt(msg.match[2] || '5')
     graylogHostMessages msg, host, count, (what) ->


### PR DESCRIPTION
Currently when you mention 'graylog' anywhere in your message, Hubot spits out some error messages.
