### PR TITLE
Implementing minime script for Server-Sent Event broadast

### DIFF
--- a/src/scripts/minime.coffee
+++ b/src/scripts/minime.coffee
@@ -1,0 +1,97 @@
+# Description:
+#   Provides a Server-Sent Events path for broadcasting messages to subscribers.
+#
+# Dependencies:
+#   None
+#
+# Commands:
+#   hubot minime <message> - sends the message to any subscribers.
+#
+# Configuration:
+#   None
+#
+# Author:
+#   jimbojw
+
+module.exports = (robot) ->
+  
+  # collection of open connections (ES6 Set would be preferable if available)
+  id = 0
+  connections = {}
+  
+  # implement SSE
+  robot.router.get '/minime/events', (req, res) ->
+    
+    req.socket.setTimeout Infinity
+    
+    res.writeHead 200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive'
+    }
+    res.write '\n'
+    
+    id = id + 1
+    res.minime_id = id
+    connections[id] = res
+    
+    res.on 'close', () ->
+      delete connections[res.minime_id]
+  
+  # repackage and post all server sent events to parent window
+  robot.router.get '/minime/iframe', (req, res) ->
+    res.writeHead 200, { 'Content-Type': 'text/html' }
+    res.end """<!doctype html>
+      <script>
+      (function(window){
+        var source = new EventSource(window.location.pathname.replace(/\\/iframe(\\/|$)/, '/events\\1'));
+        source.onmessage = function(e) {
+          window.parent.postMessage(JSON.stringify({
+            from: 'minime',
+            message: JSON.parse(e.data)
+          }), '*');
+        };
+      })(window);
+      </script>
+    """
+  
+  # test the iframe
+  robot.router.get '/minime/test', (req, res) ->
+    res.writeHead 200, { 'Content-Type': 'text/html' }
+    res.end """<!doctype html>
+      <html><head></head><body>
+      <h1>messages: <h1>
+      <script>
+      (function(window, document){
+        var iframe = document.createElement('iframe');
+        iframe.height = '1px';
+        iframe.width = '1px';
+        iframe.style.border = 'none';
+        iframe.src = './iframe';
+        window.onmessage = function(event) {
+          var payload = JSON.parse(event.data);
+          if (payload.from === 'minime') {
+            var pre = document.createElement('pre');
+            pre.appendChild(document.createTextNode(event.data));
+            document.body.appendChild(pre);
+          }
+        };
+        document.body.appendChild(iframe);
+      })(window, document);
+      </script>
+      </body></html>
+    """
+  
+  # send minime messages out to subsribers
+  robot.respond /(?:mini ?me) (.*)/i, (msg) ->
+    
+    subscribers = Object.keys(connections).length
+    s = if subscribers == 1 then '' else 's'
+      
+    if subscribers
+      msg.send 'publishing to ' + subscribers + ' minime subscriber' + s
+      for k, res of connections
+        res.write 'data: ' + JSON.stringify(msg.match[1]) + '\n\n'
+    else
+      msg.send('there are no minime subscribers at this time :(');
+


### PR DESCRIPTION
minime provides infrastructure for pushing messages from chat out to browser-based subscriber applications. This consists of a [Server-Sent Events](http://www.html5rocks.com/en/tutorials/eventsource/basics/) endpoint, and a new command for publishing messages to it from chat.

For example, say you're running hubot locally. You could have a page with this code:

```
<iframe src="http://localhost:8080/minime/iframe"></iframe>
<script>
window.onmessage = function(event) {
  if (event.origin === "http://localhost:8080/minime/iframe") {
    var payload = JSON.parse(event.data);
    // do something with payload.message
  }
};
</script>
```

Then in chat, you'd call this:

```
@hubot minime hey there
```

Inside the `onmessage` callback, the `payload.message` will be the string "hey there". Your browser-based application can do whatever it likes with this message. It could run a test case, ping a server, load a resource, etc.

The script adds `/minime/events` and `minime/iframe` to the router so those paths can be used by subscribers. The `/minime/test` path is also available as an example of how to use the iframe to subscribe to minime events across domains.
