### PR TITLE
get N builds instead of limiting lookup to most recent N builds

### DIFF
--- a/src/scripts/teamcity.coffee
+++ b/src/scripts/teamcity.coffee
@@ -93,7 +93,7 @@ module.exports = (robot) ->
     url = "#{base_url}/httpAuth/app/rest#{projectSegment}/buildTypes/name:#{encodeURIComponent(configuration)}/builds"
     msg.http(url)
       .headers(getAuthHeader())
-      .query(locator: ["lookupLimit:#{amount}","running:any"].join(","))
+      .query(locator: ["count:#{amount}","running:any"].join(","))
       .get() (err, res, body) ->
         err = body unless res.statusCode == 200
         builds = JSON.parse(body).build unless err


### PR DESCRIPTION
Using lookupLimit limits the returned results to most recent N builds of the project. This change will return N builds, regardless of whether those builds are in the last N of the project.
