### PR TITLE
Fix for Rdio links that contain a dash

### DIFF
--- a/src/scripts/rdio.coffee
+++ b/src/scripts/rdio.coffee
@@ -17,7 +17,7 @@ crypto = require "crypto"
 http = require "http"
 
 module.exports = (robot) ->
-  robot.hear /http:\/\/rd\.io\/x\/[a-zA-Z0-9]+\//i, (msg) ->
+  robot.hear /http:\/\/rd\.io\/x\/[a-zA-Z0-9\-]+\//i, (msg) ->
     rdio.request "getObjectFromUrl", {"url": msg.match[0]}, (err, data) ->
       if err
         msg.send "Rdio response: #{err}"


### PR DESCRIPTION
Here's an example that will now work:
[http://rd.io/x/QVXmwjd-hxc/](http://rd.io/x/QVXmwjd-hxc/)
Is there a better way to add the dash so that it won't be confused as a range in the future?
