### PR TITLE
Added gauges event

### DIFF
--- a/src/scripts/gauges.coffee
+++ b/src/scripts/gauges.coffee
@@ -114,14 +114,3 @@ module.exports = (robot) ->
 
       when "data"
           gauges.getViewsForDate data.day, handler
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
It's possible trigger a event to show gauges stats from another script

Something like this:

``` coffee
module.exports = (robot) ->
  robot.respond /emit gauges/i, (msg) ->
    robot.emit "gauges", { user: msg.user, for: 'today' }
```
