### PR TITLE
Stop tweet.coffee from responding to mentions of tweet with a blank query

### DIFF
--- a/src/scripts/tweet.coffee
+++ b/src/scripts/tweet.coffee
@@ -15,7 +15,7 @@
 #
 # Notes:
 #   There's an outstanding issue on AvianFlu/ntwitter#110 for search and the v1.1 API.
-#   sebhildebrandt is a fork that is working, so we recommend that for now. This 
+#   sebhildebrandt is a fork that is working, so we recommend that for now. This
 #   can be removed after the issue is fixed and a new release cut, along with updating the dependency
 #
 # Author:


### PR DESCRIPTION
Use .+ instead of .\* in the regex pattern for tweet.coffee

This prevents hubot from responding to a blank query by making sure
that something is said before the word tweet.
