### PR TITLE
Change the cash.coffee listeners so they don't collide with roles.coffee

### DIFF
--- a/src/scripts/cash.coffee
+++ b/src/scripts/cash.coffee
@@ -1,5 +1,10 @@
 # Description:
-#   allows hubot to track the cash and burn rate and displays
+#   allows hubot to track the cash and burn rate and displays a summary
+#   of the current cash state. Also stores historical values in the
+#   hubot brain so that they can be referred to later.
+#
+#   The s3-brain is HIGHLY recommended for keeping track of historical
+#   cash values and not losing everything when hubot restarts.
 #
 # Dependencies:
 #   None


### PR DESCRIPTION
While I prefer the sentence structure using the word is, the
roles.coffee script heavily listens for and responds to commands with
**is** in them. This causes a very confusing message when updating cash:

```
> hubot cash burn rate is $10,000
Ok, our burn rate is $10,000 per month
I don't know anything about cash burn rate
```

Since roles.coffee is shipped with hubot and used in a number of
other situations, I've concluded that the best course of action is to
change the listeners for this script.

I've explored other options for this, such as using "set burn rate at"
or "update burn rate to", but this seems like the simplest change
with the least amount of impact.
