### PR TITLE
A proposal to add categorisation to script metadata

### DIFF
--- a/src/scripts/46elks.coffee
+++ b/src/scripts/46elks.coffee
@@ -15,6 +15,11 @@
 #
 # Author:
 #   kimf
+#
+# Tags:
+#   text messaging
+#   notification
+#   utliity
 
 QS      = require "querystring"
 module.exports = (robot) ->

--- a/src/scripts/9gag.coffee
+++ b/src/scripts/9gag.coffee
@@ -13,6 +13,11 @@
 #
 # Author:
 #   EnriqueVidal 
+#
+# Tags:
+#   memes
+#   images
+#   fun
 
 Select      = require( "soupselect" ).select
 HTMLParser  = require "htmlparser"

--- a/src/scripts/abstract.coffee
+++ b/src/scripts/abstract.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   tantalor
+#
+# Tags:
+#   utility
 
 module.exports = (robot) ->
   robot.respond /(abs|abstract) (.+)/i, (res) ->

--- a/src/scripts/achewood.coffee
+++ b/src/scripts/achewood.coffee
@@ -16,6 +16,11 @@
 #
 # Author:
 #   1000hz
+#
+# Tags:
+#   images
+#   comics
+#   fun
 
 htmlparser = require "htmlparser"
 Select = require("soupselect").select

--- a/src/scripts/achievement_unlocked.coffee
+++ b/src/scripts/achievement_unlocked.coffee
@@ -12,6 +12,11 @@
 #
 # Author:
 #   Chris
+#
+# Tags:
+#   images
+#   memes
+#   fun
 
 module.exports = (robot) ->
   robot.hear /achievement (get|unlock(ed)?) (.+?)(\s*[^@\s]+@[^@\s]+)?\s*$/i, (msg) ->

--- a/src/scripts/ackbar.coffee
+++ b/src/scripts/ackbar.coffee
@@ -12,6 +12,11 @@
 #
 # Author:
 #   brilliantfantastic
+#
+# Tags:
+#   memes
+#   images
+#   fun
 
 ackbars = [
   "http://dayofthejedi.com/wp-content/uploads/2011/03/171.jpg",

--- a/src/scripts/adult.coffee
+++ b/src/scripts/adult.coffee
@@ -12,6 +12,11 @@
 #
 # Author:
 #   atmos
+#
+# Tags:
+#   memes
+#   images
+#   fun
 
 images = [
   "http://1.bp.blogspot.com/_D_Z-D2tzi14/TBpOnhVqyAI/AAAAAAAADFU/8tfM4E_Z4pU/s400/responsibility12(alternate).png",

--- a/src/scripts/advice.coffee
+++ b/src/scripts/advice.coffee
@@ -16,6 +16,9 @@
 # Author:
 #   pengwynn
 #
+# Tags:
+#   fun
+
 getAdvice = (msg, query) ->
   msg.http("http://api.adviceslip.com/advice/search/#{query}")
     .get() (err, res, body) ->

--- a/src/scripts/airbrake.coffee
+++ b/src/scripts/airbrake.coffee
@@ -13,6 +13,11 @@
 #
 # Author:
 #   tommeier
+#
+# Tags:
+#   monitoring
+#   notifications
+#   utility
 
 jsdom = require 'jsdom'
 env = process.env

--- a/src/scripts/alot.coffee
+++ b/src/scripts/alot.coffee
@@ -12,6 +12,11 @@
 #
 # Author:
 #   tbwIII
+#
+# Tags:
+#   memes
+#   images
+#   fun
 
 images = [
   "http://4.bp.blogspot.com/_D_Z-D2tzi14/S8TRIo4br3I/AAAAAAAACv4/Zh7_GcMlRKo/s400/ALOT.png",

--- a/src/scripts/ambush.coffee
+++ b/src/scripts/ambush.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   jmoses
+#
+# Tags:
+#   notifications
+#   utility
 
 appendAmbush = (data, toUser, fromUser, message) ->
   data[toUser.name] or= []

--- a/src/scripts/animal.coffee
+++ b/src/scripts/animal.coffee
@@ -13,6 +13,11 @@
 #
 # Author:
 #   unsay
+#
+# Tags:
+#   memes
+#   images
+#   fun
 
 Select     = require("soupselect").select
 HtmlParser = require "htmlparser"

--- a/src/scripts/announce.coffee
+++ b/src/scripts/announce.coffee
@@ -17,6 +17,10 @@
 #
 # URLS:
 #   /broadcast/create - Send a message to designated, comma-separated rooms.
+#
+# Tags:
+#   notification
+#   utility
 
 module.exports = (robot) ->
 

--- a/src/scripts/applause.coffee
+++ b/src/scripts/applause.coffee
@@ -12,6 +12,11 @@
 #
 # Author:
 #   joshfrench
+#
+# Tags:
+#   memes
+#   images
+#   fun
 
 images = [
   "http://assets0.ordienetworks.com/images/GifGuide/clapping/Kurtclapping.gif",

--- a/src/scripts/archer.coffee
+++ b/src/scripts/archer.coffee
@@ -11,6 +11,10 @@
 #
 # Author:
 #   rrix
+#
+# Tags:
+#   quotes
+#   fun
 
 scraper = require 'scraper'
 

--- a/src/scripts/asana.coffee
+++ b/src/scripts/asana.coffee
@@ -21,6 +21,9 @@
 # Author:
 #   idpro
 #   abh1nav
+#
+# Tags:
+#   productivity
 
 url  = 'https://app.asana.com/api/1.0'
 

--- a/src/scripts/ascii.coffee
+++ b/src/scripts/ascii.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   atmos
+#
+# Tags:
+#   fun
 
 module.exports = (robot) ->
   robot.respond /ascii( me)? (.+)/i, (msg) ->

--- a/src/scripts/auth.coffee
+++ b/src/scripts/auth.coffee
@@ -23,6 +23,9 @@
 #
 # Author:
 #   alexwilliamsca
+#
+# Tags:
+#   utility
 
 module.exports = (robot) ->
   admin = process.env.HUBOT_AUTH_ADMIN

--- a/src/scripts/auto-stache.coffee
+++ b/src/scripts/auto-stache.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   atmos
+#
+# Tags:
+#   images
+#   fun
 
 module.exports = (robot) ->
   robot.hear /^(https?:\/\/[^ #]+\.(?:png|jpg|jpeg))(?:[#]\.png)?$/i, (msg) ->

--- a/src/scripts/availability.coffee
+++ b/src/scripts/availability.coffee
@@ -15,6 +15,9 @@
 #
 # Author:
 #   tombell
+#
+# Tags:
+#   utility
 
 module.exports = (robot) ->
 

--- a/src/scripts/avalanche.coffee
+++ b/src/scripts/avalanche.coffee
@@ -11,6 +11,10 @@
 #
 # Author:
 #   Alastair Brunton
+# 
+# Tags:
+#   weather
+#   utility
 
 jsdom = require 'jsdom'
 

--- a/src/scripts/aws.coffee
+++ b/src/scripts/aws.coffee
@@ -25,6 +25,10 @@
 #
 # Author:
 #   Iristyle
+#
+# Tags:
+#   monitoring
+#   utility
 
 key = process.env.HUBOT_AWS_ACCESS_KEY_ID
 secret = process.env.HUBOT_AWS_SECRET_ACCESS_KEY

--- a/src/scripts/aww.coffee
+++ b/src/scripts/aww.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   eliperkins
+#
+# Tags:
+#   images
+#   fun
 
 module.exports = (robot) ->
   robot.respond /aww/i, (msg) ->

--- a/src/scripts/base64.coffee
+++ b/src/scripts/base64.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   jimeh
+# 
+# Tags:
+#   utility
 
 module.exports = (robot) ->
   robot.respond /base64 encode( me)? (.*)/i, (msg) ->

--- a/src/scripts/basecamp.coffee
+++ b/src/scripts/basecamp.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   fellix
+#
+# Tags:
+#   productivity
+#   utility
 
 module.exports = (robot) ->
   robot.hear /^basecamp calendar( (.*))?$/i, (msg) ->

--- a/src/scripts/beanstalk.coffee
+++ b/src/scripts/beanstalk.coffee
@@ -17,6 +17,10 @@
 #
 # Author:
 #   eliperkins
+#
+# Tags:
+#   productivity
+#   utility
 
 module.exports = (robot) ->
 

--- a/src/scripts/beastmode.coffee
+++ b/src/scripts/beastmode.coffee
@@ -15,6 +15,10 @@
 #
 # Author:
 #   benpink
+#
+# Tags:
+#   music
+#   utility
 
 jsdom = require 'jsdom'
 jquery = 'http://ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js'

--- a/src/scripts/beeradvocate.coffee
+++ b/src/scripts/beeradvocate.coffee
@@ -15,6 +15,11 @@
 #
 # Author:
 # whyjustin
+#
+# Tags:
+#   beer
+#   utility
+#   fun
 
 module.exports = (robot) ->
     robot.respond /beer (a|advocate)?( me)?/i, (msg) ->

--- a/src/scripts/beerme.coffee
+++ b/src/scripts/beerme.coffee
@@ -12,6 +12,11 @@
 #
 # Author:
 #  houndbee
+#
+# Tags:
+#   beer
+#   images
+#   fun
 
 beers = [
   "http://organicxbenefits.com/wp-content/uploads/2011/11/organic-beer-health-benefits.jpg",

--- a/src/scripts/bees.coffee
+++ b/src/scripts/bees.coffee
@@ -12,6 +12,11 @@
 #
 # Author:
 #   atmos
+#
+# Tags:
+#   memes
+#   images
+#   fun
 
 module.exports = (robot) ->
   robot.hear /bee+s?\b/i, (message) ->

--- a/src/scripts/bij.coffee
+++ b/src/scripts/bij.coffee
@@ -11,6 +11,9 @@
 #
 # Author:
 #   mrtazz
+#
+# Tags:
+#   fun
 
 module.exports = (robot) ->
   robot.hear /bij/i, (msg) ->

--- a/src/scripts/bing-images.coffee
+++ b/src/scripts/bing-images.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   Brandon Satrom
+#
+# Tags:
+#   images
+#   fun
 
 bingAccountKey = process.env.HUBOT_BING_ACCOUNT_KEY
 unless bingAccountKey

--- a/src/scripts/bing.coffee
+++ b/src/scripts/bing.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   Brandon Satrom
+#
+# Tags:
+#   search
+#   utility
 
 module.exports = (robot) ->
   robot.respond /(bing)( me)? (.*)/i, (msg) ->

--- a/src/scripts/birthday.coffee
+++ b/src/scripts/birthday.coffee
@@ -14,6 +14,9 @@
 #
 # Author:
 #   sopel
+#
+# Tags:
+#   fun
 
 module.exports = (robot) ->
 

--- a/src/scripts/bitbucket-activity.coffee
+++ b/src/scripts/bitbucket-activity.coffee
@@ -14,6 +14,10 @@
 #
 # Author:
 #   pyro2927
+#
+# Tags:
+#   productivity
+#   utility
 
 require('date-utils')
 

--- a/src/scripts/bitbucket.coffee
+++ b/src/scripts/bitbucket.coffee
@@ -12,6 +12,11 @@
 #
 # Author:
 #   JRusbatch
+#
+# Tags:
+#   notification
+#   productivity
+#   utility
 
 module.exports = (robot) ->
   robot.router.post '/hubot/bitbucket/:room', (req, res) ->

--- a/src/scripts/bitcoin.coffee
+++ b/src/scripts/bitcoin.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   Fred Wu
+#
+# Tags:
+#   finance
+#   utility
 
 cheerio = require('cheerio')
 

--- a/src/scripts/bitly.coffee
+++ b/src/scripts/bitly.coffee
@@ -15,6 +15,9 @@
 # Author:
 #   sleekslush
 #   drdamour
+#
+# Tags:
+#   utility
 
 module.exports = (robot) ->
   robot.respond /(bitly|shorten)\s?(me)?\s?(.+)$/i, (msg) ->

--- a/src/scripts/bookmark.coffee
+++ b/src/scripts/bookmark.coffee
@@ -18,8 +18,11 @@
 #   hubot list links - List all of the links that are being tracked
 #   hubot feed me - get the URL to subscribe to your bookmark rss
 #
-# Author
+# Author:
 #   mm53bar
+#
+# Tags:
+#   utility
 
 module.exports = (robot) ->
   robot.respond /feed me/i, (msg) ->

--- a/src/scripts/botsnack.coffee
+++ b/src/scripts/botsnack.coffee
@@ -13,6 +13,9 @@
 # Author:
 #   richo
 #   locherm
+#
+# Tags:
+#   fun
 
 responses = [
   "Om nom nom!",

--- a/src/scripts/brb.coffee
+++ b/src/scripts/brb.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   jmhobbs
+#
+# Tags:
+#   communication
+#   utility
 
 module.exports = (robot) ->
 

--- a/src/scripts/brewerydb.coffee
+++ b/src/scripts/brewerydb.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   greggroth
+#
+# Tags:
+#   beer
+#   utility
 
 module.exports = (robot) ->
   robot.respond /beer me (.*)/i, (msg) ->

--- a/src/scripts/buscemi.coffee
+++ b/src/scripts/buscemi.coffee
@@ -13,6 +13,11 @@
 #
 # Author:
 #   dylanegan
+#
+# Tags:
+#   memes
+#   images
+#   fun
 
 module.exports = (robot) ->
   robot.respond /buscemi?(?: me)? (.*)/i, (msg) ->

--- a/src/scripts/calm-down.coffee
+++ b/src/scripts/calm-down.coffee
@@ -8,6 +8,10 @@
 #   hubot calm me | manatee me - Reply with Manatee
 #   calm down | simmer down | that escalated quickly - Reply with Manatee
 #   ALL CAPS | LONGCAPS - Reply with Manatee
+#
+# Tags:
+#   fun
+#   images
 
 module.exports = (robot) ->
   manatee = ->

--- a/src/scripts/capgun.coffee
+++ b/src/scripts/capgun.coffee
@@ -17,6 +17,10 @@
 #
 # Author:
 #   monde
+#
+# Tags:
+#   utility
+#   images
 
 module.exports = (robot) ->
   robot.respond /cap (.*)/i, (msg) ->

--- a/src/scripts/carlton.coffee
+++ b/src/scripts/carlton.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   pingles
+#
+# Tags:
+#   fun
+#   images
 
 carltons = [
   "http://media.tumblr.com/tumblr_lrzrlymUZA1qbliwr.gif",

--- a/src/scripts/cash.coffee
+++ b/src/scripts/cash.coffee
@@ -22,6 +22,10 @@
 #
 # Author:
 #   jhubert
+#
+# Tags:
+#   utility
+#   productivity
 
 class OutputFormatter
   months: [ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" ]

--- a/src/scripts/cat.coffee
+++ b/src/scripts/cat.coffee
@@ -16,6 +16,10 @@
 #
 # Author:
 #   simon
+#
+# Tags:
+#   utility
+#   messaging
 
 dgram = require "dgram"
 server = dgram.createSocket "udp4"

--- a/src/scripts/catfacts.coffee
+++ b/src/scripts/catfacts.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   scottmeyer
+#
+# Tags:
+#   fun
 
 module.exports = (robot) ->
 	robot.respond /CATFACT$/i, (msg) ->

--- a/src/scripts/celery-man.coffee
+++ b/src/scripts/celery-man.coffee
@@ -11,6 +11,10 @@
 #
 # Author:
 #   danryan
+#
+# Tags:
+#   fun
+#   images
 
 module.exports = (robot) ->
   robot.respond /.*celery\s?man/i, (msg) ->

--- a/src/scripts/chartbeat.coffee
+++ b/src/scripts/chartbeat.coffee
@@ -21,6 +21,11 @@
 #
 # Author:
 #   Drew Delianides
+#
+# Tags:
+#   utility
+#   monitoring
+
 
 getChart = (msg, apiKey, site) ->
   msg.robot.http("http://api.chartbeat.com/live/quickstats/v3/?apikey=#{apiKey}&host=#{site}")

--- a/src/scripts/chat.coffee
+++ b/src/scripts/chat.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   GantMan
+#
+# Tags:
+#   fun
 
 module.exports = (robot) ->
   robot.respond /chat/i, (msg) ->

--- a/src/scripts/cheer.coffee
+++ b/src/scripts/cheer.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   carllerche
+#
+# Tags:
+#   fun
+#   images
 
 module.exports = (robot) ->
   robot.respond /cheer me up/i, (msg) ->

--- a/src/scripts/cheerlights.coffee
+++ b/src/scripts/cheerlights.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   marciotoshio
+#
+# Tags:
+#   fun
 
 module.exports = (robot) ->
   robot.respond /cheerlights/i, (msg) ->

--- a/src/scripts/chess.coffee
+++ b/src/scripts/chess.coffee
@@ -15,6 +15,9 @@
 # Author:
 #   thallium205
 #
+#
+# Tags:
+#   fun
 
 Chess = require 'chess'
 

--- a/src/scripts/chm.coffee
+++ b/src/scripts/chm.coffee
@@ -13,6 +13,9 @@
 #
 # Author:
 #   facto
+#
+# Tags:
+#   fun
 
 Select     = require("soupselect").select
 HtmlParser = require "htmlparser"

--- a/src/scripts/chopapp.coffee
+++ b/src/scripts/chopapp.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   kristofbc
+#
+# Tags:
+#   utility
 
 module.exports = (robot) ->
 	robot.respond /chop (me )?(in )?(\w+) (.*)$/i, (msg) ->

--- a/src/scripts/chuck-norris.coffee
+++ b/src/scripts/chuck-norris.coffee
@@ -13,6 +13,11 @@
 #
 # Author:
 #   dlinsin
+#
+# Tags:
+#   fun
+#   images
+#   memes
 
 module.exports = (robot) ->
 

--- a/src/scripts/clark.coffee
+++ b/src/scripts/clark.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   ajacksified
+#
+# Tags:
+#   utility
 
 clark = require('clark').clark
 

--- a/src/scripts/cleverbot.coffee
+++ b/src/scripts/cleverbot.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   ajacksified
+#
+# Tags:
+#   fun
 
 cleverbot = require('cleverbot-node')
 

--- a/src/scripts/clojure.coffee
+++ b/src/scripts/clojure.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   jingweno
+#
+# Tags:
+#   utility
 
 ringSessionID = ''
 

--- a/src/scripts/cloudapp.coffee
+++ b/src/scripts/cloudapp.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   lmarburger
+#
+# Tags:
+#   utility
 
 module.exports = (robot) ->
   robot.hear /(https?:\/\/cl.ly\/image\/[A-Za-z0-9]+)(\/[^\/]+)?/i, (msg) ->

--- a/src/scripts/coderwall.coffee
+++ b/src/scripts/coderwall.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   mexitek
+#
+# Tags:
+#   fun
+#   monitoring
 
 module.exports = (robot) ->
   robot.respond /(coderwall)( me)? (.*)/i, (msg) ->

--- a/src/scripts/coin.coffee
+++ b/src/scripts/coin.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   mrtazz
+#
+# Tags:
+#   utility
 
 thecoin = ["heads", "tails"]
 

--- a/src/scripts/commandlinefu.coffee
+++ b/src/scripts/commandlinefu.coffee
@@ -13,6 +13,9 @@
 #
 # Author:
 #   aaronott
+#
+# Tags:
+#   fun
 
 module.exports = (robot) ->
   robot.respond /commandlinefu(?: me)? *(.*)?/i, (msg) ->

--- a/src/scripts/commitmessage.coffee
+++ b/src/scripts/commitmessage.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   mrtazz
+#
+# Tags:
+#   fun
 
 module.exports = (robot) ->
   robot.respond /commit message/i, (msg) ->

--- a/src/scripts/complete.coffee
+++ b/src/scripts/complete.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   aroben
+#
+# Tags:
+#   fun
+#   search
 
 XMLJS = require("xml2js")
 

--- a/src/scripts/conversation.coffee
+++ b/src/scripts/conversation.coffee
@@ -12,6 +12,10 @@
 #
 # Author:
 #   pescuma
+#
+# Tags:
+#   utility
+#   notification
 
 module.exports = (robot) ->
   robot.eatListeners = {}

--- a/src/scripts/corgime.coffee
+++ b/src/scripts/corgime.coffee
@@ -13,6 +13,10 @@
 #
 # Author:
 #   alexgodin
+#
+# Tags:
+#   fun
+#   images
 
 module.exports = (robot) ->
 

--- a/src/scripts/cowsay.coffee
+++ b/src/scripts/cowsay.coffee
@@ -12,6 +12,9 @@
 #
 # Author:
 #   brettbuddin
+#
+# Tags:
+#   fun
 
 module.exports = (robot) ->
   robot.respond /cowsay( me)? (.*)/i, (msg) ->

--- a/src/scripts/cricket.coffee
+++ b/src/scripts/cricket.coffee
@@ -13,6 +13,10 @@
 #
 # Author:
 #   adtaylor
+#
+# Tags:
+#   fun
+#   sports
 
 module.exports = (robot) ->
   feed_url = "http://query.yahooapis.com/v1/public/yql?q=select%20title%20from%20rss%20where%20url%3D%22http%3A%2F%2Fstatic.cricinfo.com%2Frss%2Flivescores.xml%22&format=json&diagnostics=true&callback="

--- a/src/scripts/crossing.coffee
+++ b/src/scripts/crossing.coffee
@@ -1,6 +1,9 @@
 # Gets border waiting times to US.
 #
 # crossing <port_name>
+#
+# Tags:
+#   utility
 
 parser = require('xml2json');
 

--- a/src/scripts/cumberbatch.coffee
+++ b/src/scripts/cumberbatch.coffee
@@ -13,6 +13,10 @@
 #
 # Author:
 #   froots
+#
+# Tags:
+#   fun
+#   twitter
 
 module.exports = (robot) ->
   robot.hear /cumberbatch/i, (msg) ->


### PR DESCRIPTION
Hi there,

When I first hacked together the [Hubot Script Catalog](http://hubot-script-catalog.herokuapp.com/) there were, I think, less than a hundred scripts. Going through each script was a pain, so I created the catalog to view them all as a single page.

Today, we're approaching 500, and the catalog itself is getting somewhat unwieldy. It would be nice to categorise these scripts, to make them easier to sort through.

I was thinking of adding a new, optional section to the script metadata: Tags. I'd like to support something like:

```ruby
# Commands:
#   it's a trap - Display an Admiral Ackbar piece of wonder
#
# Author:
#   brilliantfantastic
#
# Tags:
#   memes
#   image macros
#   humorous
```

As far as I'm aware, this shouldn't break any existing Hubot documentation parsing. If supported, I could use this to build categories to browse through on the Script Catalog.

If this sounds good to you, I'm happy to tag the existing ones to organise them and set the precedent for subsequent script submissions.