### PR TITLE
Added selector argument to collection.update for mongolab-brain's save h...

### DIFF
--- a/src/scripts/mongolab-brain.coffee
+++ b/src/scripts/mongolab-brain.coffee
@@ -58,7 +58,7 @@ module.exports = (robot) ->
           opts =
             safe: true
             upsert: true
-          collection.update data, opts, (err) ->
+          collection.update {}, data, opts, (err) ->
             throw err if err?
 
       robot.brain.on 'close', ->


### PR DESCRIPTION
The save handler for mongolab-brain is missing the "selector" argument when it calls mongodb's collection.update method to save data to mongolab. The call appears to succeed, but as a result the remaining arguments are mapped to the incorrect parameters; the data never actually makes it all the way to mongolab and therefore nothing persists.

Adding a selector argument (an empty selector, as used elsewhere in the script) fixes the problem, and data persists as it should.
