### PR TITLE
Add system utilities script

### DIFF
--- a/src/scripts/system.coffee
+++ b/src/scripts/system.coffee
@@ -1,0 +1,23 @@
+# Description
+#   System utilities for Hubot
+#
+# Commands:
+#   hubot shell <command> - execute a shell command
+#
+# Notes:
+#   This is a dangerous script, it exposes a security hole.
+#   Use at your own risk.
+#
+# Author:
+#   spajus
+
+child_process = require 'child_process'
+
+module.exports = (robot) ->
+
+  robot.respond /shell (.+)/i, (msg) ->
+    child_process.exec msg.match[1], (error, stdout, stderr) ->
+      if error
+        msg.send "Error: #{stderr.trim()}"
+      else
+        msg.send stdout.trim()


### PR DESCRIPTION
So far only one, yet very powerful command:
`hubot system <command>` - runs a command on server where hubot is installed.

Inspired by the technique used in recent PR: https://github.com/github/hubot-scripts/pull/1089 by @ianmurrays
