### PR TITLE
Fix a bug setting reminders more than 24 days

### DIFF
--- a/src/scripts/remind.coffee
+++ b/src/scripts/remind.coffee
@@ -47,12 +47,12 @@ class Reminders
         # setTimeout uses a 32-bit INT
         extendTimeout = (timeout, callback) ->
           if timeout > 0x7FFFFFFF
-            setTimeout ->
+            @current_timeout = setTimeout ->
               extendTimeout (timeout - 0x7FFFFFFF), callback
             , 0x7FFFFFFF
           else
-            setTimeout callback, timeout
-        @current_timeout = extendTimeout @cache[0].due - now, trigger
+            @current_timeout = setTimeout callback, timeout
+        extendTimeout @cache[0].due - now, trigger
 
 class Reminder
   constructor: (@msg_envelope, @time, @action) ->


### PR DESCRIPTION
I was unable to set reminders to more than 24 days :panda_face: .. turns out JavaScript's `setTimeout`, which uses milliseconds, has a maximum 32-BIT INT.

For this reason, the highest value was `0x7FFFFFFF` or `2147483647` or `2^31-1`.

I created a recursive function called `extendTimeout` which loops over and sets a new timeout every ~24 days. This allows you to set reminders way far in the future.
