### PR TITLE
Fix pagerduty not finding users

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -48,7 +48,6 @@ inspect = require('util').inspect
 
 moment = require('moment')
 
-pagerDutyUsers = {}
 pagerDutyApiKey        = process.env.HUBOT_PAGERDUTY_API_KEY
 pagerDutySubdomain     = process.env.HUBOT_PAGERDUTY_SUBDOMAIN
 pagerDutyBaseUrl       = "https://#{pagerDutySubdomain}.pagerduty.com/api/v1"
@@ -305,18 +304,6 @@ module.exports = (robot) ->
     pagerDutyGet msg, "/schedules/#{pagerDutyScheduleId}/entries", query, (json) ->
       if json.entries and json.entries.length > 0
         cb(json.entries[0].user.name)
-
-  withPagerDutyUsers = (msg, cb) ->
-    if pagerDutyUsers['loaded'] != true
-      pagerDutyGet msg, "/users", {}, (json) ->
-        pagerDutyUsers['loaded'] = true
-        for user in json.users
-          pagerDutyUsers[user.id] = user
-          pagerDutyUsers[user.email] = user
-          pagerDutyUsers[user.name] = user
-        cb(pagerDutyUsers)
-    else
-      cb(pagerDutyUsers)
 
   pagerDutyIncident = (msg, incident, cb) ->
     pagerDutyGet msg, "/incidents/#{encodeURIComponent incident}", {}, (json) ->


### PR DESCRIPTION
The API uses [pagination](http://developer.pagerduty.com/documentation/rest/pagination), and we were simply getting all users without any filters. We ran into a case where we had too many users to fit on a single page, so the script got confused and didn't think they had a user.

This fixes it to search by email address.
