### PR TITLE
Limit tweet regex to be at the end of the word.

### DIFF
--- a/src/scripts/tweet.coffee
+++ b/src/scripts/tweet.coffee
@@ -33,7 +33,7 @@ module.exports = (robot) ->
 
   twit = undefined
 
-  robot.respond /(.+) tweet/i, (msg) ->
+  robot.respond /(.+) tweet(\s*)?$/i, (msg) ->
     unless auth.consumer_key
       msg.send "Please set the HUBOT_TWITTER_CONSUMER_KEY environment variable."
       return


### PR DESCRIPTION
Without this, anytime you mention the word tweet in a hubot command, it
treats it as a thing to find a tweet for.
