### PR TITLE
deploy.coffee -- check if bot.Room is defined

### DIFF
--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -40,7 +40,7 @@ module.exports = (robot) ->
     message += " version " + version if version
 
     robot.send(user, message)
-    if robot.adapter.bot?
+    if robot.adapter.bot?.Room?
       robot.adapter.bot.Room(user.room).sound "trombone", (err, data) =>
         console.log "campfire error: #{err}" if err
 


### PR DESCRIPTION
Hi there,

the deploy.coffee script doesn't work well with the IRC adapter, since it relies on robot.adapter.bot.Room to be defined (which isn't however).

```
TypeError: Object #<Client> has no method 'Room'
  at /home/stesie/Projekte/stella/node_modules/hubot-scripts/src/scripts/deploy.coffee:44:7, <js>:24:27
  at callbacks (/home/stesie/Projekte/stella/node_modules/hubot/node_modules/express/lib/router/index.js:161:37)
  at param (/home/stesie/Projekte/stella/node_modules/hubot/node_modules/express/lib/router/index.js:135:11)
  at pass (/home/stesie/Projekte/stella/node_modules/hubot/node_modules/express/lib/router/index.js:142:5)
  at Router._dispatch (/home/stesie/Projekte/stella/node_modules/hubot/node_modules/express/lib/router/index.js:170:5)
[...]
```

cheers
  stesie
