### PR TITLE
Default to using JIRA API v2

### DIFF
--- a/src/scripts/jira.coffee
+++ b/src/scripts/jira.coffee
@@ -9,7 +9,7 @@
 #   HUBOT_JIRA_USER
 #   HUBOT_JIRA_PASSWORD
 #   Optional environment variables:
-#   HUBOT_JIRA_USE_V2
+#   HUBOT_JIRA_USE_V2 (defaults to "true", set to "false" for JIRA earlier than 5.0)
 #   HUBOT_JIRA_MAXLIST
 #   HUBOT_JIRA_ISSUEDELAY
 #   HUBOT_JIRA_IGNOREUSERS
@@ -90,7 +90,7 @@ class RecentIssues
 module.exports = (robot) ->
   filters = new IssueFilters robot
 
-  useV2 = process.env.HUBOT_JIRA_USE_V2 || false
+  useV2 = process.env.HUBOT_JIRA_USE_V2 != "false"
   # max number of issues to list during a search
   maxlist = process.env.HUBOT_JIRA_MAXLIST || 10
   # how long (seconds) to wait between repeating the same JIRA issue link


### PR DESCRIPTION
Avoids https://github.com/github/hubot-scripts/issues/1088 for the majority of new users (who should be on 5.0 or higher, seeing as it's been out for almost 2 years and Atlassian is now gearing up to release 6.1).
