### PR TITLE
Stop joining URL sent by the feed

### DIFF
--- a/src/scripts/quakes.coffee
+++ b/src/scripts/quakes.coffee
@@ -32,7 +32,7 @@ module.exports = (robot)->
         count++
         quake = quake.properties
         time  = build_time quake
-        url   = [ lookup_site, quake.url ].join ''
+        url   = quake.url
 
         message.send "Magnitude: #{ quake.mag }, Location: #{ quake.place }, Time: #{ time } - #{ url }"
 


### PR DESCRIPTION
http://earthquake.usgs.gov now provides full URL so this is no longer needed.
