### PR TITLE
Updates to applause.coffee

### DIFF
--- a/src/scripts/applause.coffee
+++ b/src/scripts/applause.coffee
@@ -8,8 +8,8 @@
 #   None
 #
 # Commands:
-#   (applause|applaud|bravo|slow clap) - Get applause
-#   (sarcastic applause|clap) - Get sarcastic applause
+#   applause|applaud|bravo|slow clap - Get applause
+#   sarcastic applause|clap - Get sarcastic applause
 #
 # Author:
 #   joshfrench
@@ -62,5 +62,6 @@ images =
   ]
 
 module.exports = (robot) ->
-  robot.hear /applau(d|se)|bravo|slow clap/i, (msg) ->
-    msg.send msg.random images.sincere
+  robot.hear /applau(d|se)|bravo|sarcastic applause|(slow|sarcastic) clap/i, (msg) ->
+    type = if (/sarcastic/i).test(msg.message.text) then images.insincere else images.sincere
+    msg.send msg.random type


### PR DESCRIPTION
I added some more images to the applause gif array and split them into two versions: sincere and insincere.

Now you can say 'applause' for sincere gifs and 'sarcastic applause' for sarcastic gifs.
