### PR TITLE
Allow uppercase names in Asana task assignments

### DIFF
--- a/src/scripts/asana.coffee
+++ b/src/scripts/asana.coffee
@@ -72,6 +72,7 @@ module.exports = (robot) ->
     if userAcct
       userAcct = userAcct.replace /^\s+|\s+$/g, ""
       userAcct = userAcct.replace "@", ""
+      userAcct = userAcct.toLowerCase()
       getRequest msg, "/workspaces/#{workspace}/users", (err, res, body) ->
         response = JSON.parse body
         assignedUser = ""


### PR DESCRIPTION
Because the code does a `toLowerCase()` on the names coming from API data (https://github.com/github/hubot-scripts/blob/master/src/scripts/asana.coffee#L79), Hubot command necessarily has to take a lowercase form or the equality (https://github.com/github/hubot-scripts/blob/master/src/scripts/asana.coffee#L80) doesn't return true 

`task: @Taylor blah`

> Unable to Assign User
> Task Created : blah

`task: @taylor blah`

> Task Created : blah : Assigned to @taylor

If we `toLowerCase()` input data as well, the check should pass and using lowercased names in task assignments should not longer be necessary.

Cross-pulled to https://github.com/idpro/hubot-asana/pull/2 
