### PR TITLE
Switch jira ticket method from respond to hear.

### DIFF
--- a/src/scripts/jira.coffee
+++ b/src/scripts/jira.coffee
@@ -185,7 +185,7 @@ module.exports = (robot) ->
     search msg, msg.match[2], (text) ->
       msg.reply text
   
-  robot.respond /([^\w\-]|^)(\w+-[0-9]+)(?=[^\w]|$)/ig, (msg) ->
+  robot.hear /([^\w\-]|^)(\w+-[0-9]+)(?=[^\w]|$)/ig, (msg) ->
     if msg.message.user.id is robot.name
       return
 


### PR DESCRIPTION
The description states the bot should respond to ticket id mentions but at the minute the bot has to be addressed directly for this to happen. This changes the functionality to bring it in line with the doc block.