### PR TITLE
Changed the way the envelope.user is build so it won't clash with hubot-irc

### DIFF
--- a/src/scripts/jenkins-notifier.coffee
+++ b/src/scripts/jenkins-notifier.coffee
@@ -58,10 +58,11 @@ module.exports = (robot) ->
     res.end('')
 
     envelope = {notstrat:"Fs"}
-    envelope.user = {}
     envelope.room = query.room if query.room
-    envelope.user.type = query.type if query.type
     envelope.notstrat = query.notstrat if query.notstrat 
+    if query.type
+      envelope.user = {type: query.type}
+
     try
       data = req.body
 


### PR DESCRIPTION
Hubot-irc checks if the envelope.user var exists, and if so, it takes the room from it. Obviously, that var doesn't exist, so it can not post the message to any rooms.
This fix should only create an envelope.user if the roomtype is given, which is not used by hubot-irc, so that should be safe.

This fixes the following error, upon a callback from jenkins, which prevents it from posting to a room:

```
ERROR: err_nosuchnick: hubot [object No such nick/channel
```
