### PR TITLE
sudo no longer captures space following command

### DIFF
--- a/src/scripts/sudo.coffee
+++ b/src/scripts/sudo.coffee
@@ -14,5 +14,5 @@
 #   searls
 
 module.exports = (robot) ->
-  robot.respond /(sudo)(.*)/i, (msg) ->
-    msg.send "Alright. I'll #{msg.match?[2] || "do whatever it is you wanted."}"
+  robot.respond /(?:sudo) ?(.*)/i, (msg) ->
+    msg.send "Alright. I'll #{msg.match?[1] || "do whatever it is you wanted."}"


### PR DESCRIPTION
The regular expression used here used to capture the space separating sudo from the rest of the command. When interpolated, this resulted in a double space like:

```
Alright, I'll  make you a sandwich.
```
