### PR TITLE
Handle error for stock info request

### DIFF
--- a/src/scripts/stock.coffee
+++ b/src/scripts/stock.coffee
@@ -18,6 +18,9 @@ module.exports = (robot) ->
     ticker = escape(msg.match[2])
     msg.http('http://finance.google.com/finance/info?client=ig&q=' + ticker)
       .get() (err, res, body) ->
-        result = JSON.parse(body.replace(/\/\/ /, ''))
+        if err or !body
+          msg.send 'There was an error looking up stock information.'
+        else
+          result = JSON.parse(body.replace(/\/\/ /, ''))
 
-        msg.send result[0].l_cur + "(#{result[0].c})"
+          msg.send result[0].l_cur + "(#{result[0].c})"


### PR DESCRIPTION
We should handle the error for this callback, specifically in the case where the ticker doesn't match any existing company. Oddly enough when the ticker doesn't exist, the `err` object is still `null` but `body` is an empty string. This commit ensures `JSON.parse` isn't called on an empty string, preventing hubot from dying.