### PR TITLE
Fix regular expression in plusplus script to properly match umlauts

### DIFF
--- a/src/scripts/plusplus.coffee
+++ b/src/scripts/plusplus.coffee
@@ -104,7 +104,7 @@ class ScoreKeeper
 module.exports = (robot) ->
   scoreKeeper = new ScoreKeeper(robot)
 
-  robot.hear /([\w\s]+)([\W\S]*)?(\+\+)$/i, (msg) ->
+  robot.hear /([\w\S]+)([\W\s]*)?(\+\+)$/i, (msg) ->
     name = msg.match[1].trim().toLowerCase()
     from = msg.message.user.name.toLowerCase()
 
@@ -112,7 +112,7 @@ module.exports = (robot) ->
 
     if newScore? then msg.send "#{name} has #{newScore} points."
 
-  robot.hear /([\w\s]+)([\W\S]*)?(\-\-)$/i, (msg) ->
+  robot.hear /([\w\S]+)([\W\s]*)?(\-\-)$/i, (msg) ->
     name = msg.match[1].trim().toLowerCase()
     from = msg.message.user.name.toLowerCase()
 


### PR DESCRIPTION
The previous regular expression would not correctly match inputs like "Björn ++" or "Björn --", because it expected a group of word-characters or whitespace-characters followed by a group of non-word-characters or non-whitespace-characters.

With this fix the regular expression now expects a group of word-characters or non-space-characters followed by a group of non-word-characters or space-characters.
