### PR TITLE
fixed typo on mantee

### DIFF
--- a/src/scripts/manatee.coffee
+++ b/src/scripts/manatee.coffee
@@ -3,7 +3,7 @@
 #
 # Dependencies:
 #   "htmlparser": "1.7.6"
-#   "soupselect: "0.2.0"
+#   "soupselect": "0.2.0"
 #
 # Configuration:
 #   None


### PR DESCRIPTION
Lost double-quote after `soupselect`.
