### PR TITLE
fixed clark in plusplus

### DIFF
--- a/src/scripts/plusplus.coffee
+++ b/src/scripts/plusplus.coffee
@@ -18,7 +18,7 @@
 #   ajacksified
 
 _ = require("underscore")
-clark = require("clark").clark
+clark = require("clark")
 
 class ScoreKeeper
   constructor: (@robot) ->


### PR DESCRIPTION
clark added a breaking change in 0.0.6 (the version specified) to return a function, not an object: https://github.com/ajacksified/Clark/
