### PR TITLE
update jquery selector for first google search result to new page structure

### DIFF
--- a/src/scripts/howdoi.coffee
+++ b/src/scripts/howdoi.coffee
@@ -34,7 +34,7 @@ module.exports = (robot) ->
             if jQuery('*:contains("did not match any documents.")').length > 0
                 message.send "Sorry, I don't know anything about that.\n"
             else
-                first_sresult = jQuery("a.l:first").attr('href')
+                first_sresult = jQuery(".r a:first").attr('href')
                 options.uri = first_sresult
                 message.send options.uri
                 scraper options, (err, jQuery) ->


### PR DESCRIPTION
The howdoi script fetches a google search result page, and uses jquery to find the first search result. Google must have changed the structure of their page, and the jquery selector must not have gotten updated, because 

``` coffee
jQuery("a.l:first")
```

returns an empty array, []. Changing it to

``` coffee
jQuery(".r a:first")
```

fetches the correct element.
