### PR TITLE
Adjust the thank-you script to use word boundaries

### DIFF
--- a/src/scripts/polite.coffee
+++ b/src/scripts/polite.coffee
@@ -40,7 +40,7 @@ farewellResponses = [
 youTalkinToMe = (msg, robot) ->
   input = msg.message.text.toLowerCase()
   name = robot.name.toLowerCase()
-  input.indexOf(name) != -1
+  input.match(new RegExp('\\b' + name + '\\b', 'i')) !== null
 
 module.exports = (robot) ->
   robot.hear /\b(thanks|thank you|cheers|nice one)\b/i, (msg) ->


### PR DESCRIPTION
At our company, we have an employee whose name is a substring of our Hubot instance's name.  This fixes that.
