### PR TITLE
Basic random BOFH excuse generator

### DIFF
--- a/src/scripts/bofh.coffee
+++ b/src/scripts/bofh.coffee
@@ -1,5 +1,5 @@
 # Description:
-#   BOFH-style excuse generator
+#   BOFH-style excuse generator.
 #
 # Dependencies:
 #   None
@@ -9,6 +9,9 @@
 #
 # Commands:
 #   bofh me - get a random BOFH excuse
+#
+# Notes:
+#   These excuses were pulled from Jeff Ballard's BOFH Server, in turn based on Simon Paul Travaglia's stories
 #
 # Author:
 #   arsenio


### PR DESCRIPTION
This will select at random a BOFH-style excuse. Note that this has a comprehensive list in the script, and doesn't need to communicate with another server to produce results.
