### PR TITLE
fix git-help.coffee

### DIFF
--- a/src/scripts/git-help.coffee
+++ b/src/scripts/git-help.coffee
@@ -34,7 +34,7 @@ module.exports = (robot) ->
       name = $.trim $('#header .sectionbody .paragraph').text()
       desc = $.trim $('#_synopsis + .sectionbody').text()
       if desc == ''
-      desc = $.trim $('#_synopsis + .verseblock').text()
+        desc = $.trim $('#_synopsis + .verseblock').text()
 
       if name and desc
         msg.send name


### PR DESCRIPTION
Some git-help commands dont work, like "git help merge". This patch should fix them.
