### PR TITLE
Add confirmation message to tell responder

### DIFF
--- a/src/scripts/tell.coffee
+++ b/src/scripts/tell.coffee
@@ -26,6 +26,7 @@ module.exports = (robot) ->
        localstorage[room][username] += tellmessage
      else
        localstorage[room][username] = tellmessage
+     msg.send "Ok, I'll tell #{username} you said '#{msg.match[2]}'."
      return
  
    # When a user enters, check if someone left them a message


### PR DESCRIPTION
Acknowledged, this breaks the Rule of Silence.
Acknowledged, hard-coded English.

My peers considered doing so a lesser-evil to what we occasionally experience while running Hubot on a free Heroku account: messages _never being delivered_ because the sender had no way of knowing that Hubot never saw the command.

I'll let the keepers of the repo determine if they agree enough to merge!
