### PR TITLE
polite.coffee: Replace !== with ? (the coffeescript null check)

### DIFF
--- a/src/scripts/polite.coffee
+++ b/src/scripts/polite.coffee
@@ -40,7 +40,7 @@ farewellResponses = [
 youTalkinToMe = (msg, robot) ->
   input = msg.message.text.toLowerCase()
   name = robot.name.toLowerCase()
-  input.match(new RegExp('\\b' + name + '\\b', 'i')) !== null
+  input.match(new RegExp('\\b' + name + '\\b', 'i'))?
 
 module.exports = (robot) ->
   robot.hear /\b(thanks|thank you|cheers|nice one)\b/i, (msg) ->


### PR DESCRIPTION
!== causes compilation problems with the most recent version of coffeescript and hubot

Mon Dec 02 2013 16:04:50 GMT-0800 (PST)] ERROR Unable to load /src/hubot-scripts/src/scripts/polite: SyntaxError: unexpected =
  at Object.exports.throwSyntaxError (/src/hubot/node_modules/coffee-script/lib/coffee-script/helpers.js:197:13)
  at Object.parser.yy.parseError (/src/hubot/node_modules/coffee-script/lib/coffee-script/coffee-script.js:265:20)
  at Object.parse (/src/hubot/node_modules/coffee-script/lib/coffee-script/parser.js:537:22)
  at exports.compile.compile (/src/hubot/node_modules/coffee-script/lib/coffee-script/coffee-script.js:35:24)
  at Object.loadFile (/src/hubot/node_modules/coffee-script/lib/coffee-script/coffee-script.js:176:14)
  at Module.load (/src/hubot/node_modules/coffee-script/lib/coffee-script/coffee-script.js:211:36)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Robot.loadFile (/src/hubot/src/robot.coffee:181:9, <js>:133:11)
  at Robot.loadHubotScripts (/src/hubot/src/robot.coffee:208:7, <js>:166:28)
  at /src/hubot/bin/hubot:98:15, <js>:99:30
  at fs.js:266:14
  at Object.oncomplete (fs.js:107:15)
