### PR TITLE
Add a script to post sound messages on Hall's rooms

### DIFF
--- a/src/scripts/hall-sound-me.coffee
+++ b/src/scripts/hall-sound-me.coffee
@@ -64,7 +64,9 @@ module.exports = (robot) ->
   speakIt = (msg, name, link) ->
     token = auth[msg.message.user.room_id]
     if(token)
-      data = QS.stringify({'title': "#{name}", 'picture':"http://imageshack.com/a/img31/9652/979g.png", 'message':"<audio controls><source src=\"#{link}\" type=\"audio/mpeg\">Your browser doesn't support it</audio>"})
+      data = QS.stringify({'title': "#{name}",
+        'picture':"http://imageshack.com/a/img834/1557/r5vl.gif",
+        'message':"<audio controls><source src=\"#{link}\" type=\"audio/mpeg\">Your browser doesn't support it</audio>"})
       msg.http("https://hall.com/api/1/services/generic/#{token}")
         .post(data)
     else


### PR DESCRIPTION
This script uses Hall's API to send an message with HTML5 audio tag
Hall: www.hall.com

Post sounds with autoplay disabled is just for fun and make the room more interactive!

With it you'll be able to record sounds links with key like:
_hubot record sound sample www.fakewebsite.com/sample.mp3_
and post:
_hubot sound me sample_
