### PR TITLE
Take robot name for routing instead of hubot

### DIFF
--- a/src/scripts/jenkins-notifier.coffee
+++ b/src/scripts/jenkins-notifier.coffee
@@ -50,7 +50,7 @@ shouldNotify = (notstrat, data, @failing) ->
 
 module.exports = (robot) ->
 
-  robot.router.post "/hubot/jenkins-notify", (req, res) ->
+  robot.router.post "/#{robot.name}/jenkins-notify", (req, res) ->
 
     @failing ||= []
     query = querystring.parse(url.parse(req.url).query)


### PR DESCRIPTION
Akin to https://github.com/github/hubot/blob/master/src/scripts/help.coffee - the routing should respect the name of the robot passed into the command line.

This change will keep the default "hubot" route unless the name is changed.