### PR TITLE
Fixed Command Block in docs

### DIFF
--- a/src/scripts/aww.coffee
+++ b/src/scripts/aww.coffee
@@ -8,7 +8,7 @@
 #   None
 #
 # Commands:
-#   aww - Display the picture from /r/aww
+#   hubot aww - Display the picture from /r/aww
 #
 # Author:
 #   eliperkins


### PR DESCRIPTION
Since this is using robot.respond it has to take the robot's name in front of it.

Cheers,

Christian
