### PR TITLE
[tweeter] Don't crash when HUBOT_TWEETER_ACCOUNTS is unset.

### DIFF
--- a/src/scripts/tweeter.coffee
+++ b/src/scripts/tweeter.coffee
@@ -40,14 +40,16 @@ Twit = require "twit"
 config =
   consumer_key: process.env.HUBOT_TWITTER_CONSUMER_KEY
   consumer_secret: process.env.HUBOT_TWITTER_CONSUMER_SECRET
-  accounts: JSON.parse(process.env.HUBOT_TWEETER_ACCOUNTS)
+  accounts_json: process.env.HUBOT_TWEETER_ACCOUNTS
 
 unless config.consumer_key
   console.log "Please set the HUBOT_TWITTER_CONSUMER_KEY environment variable."
 unless config.consumer_secret
   console.log "Please set the HUBOT_TWITTER_CONSUMER_SECRET environment variable."
-unless config.accounts
+unless config.accounts_json
   console.log "Please set the HUBOT_TWEETER_ACCOUNTS environment variable."
+
+config.accounts = JSON.parse(config.accounts_json || "{}")
 
 module.exports = (robot) ->
   robot.respond /tweet\@([^\s]+)$/i, (msg) ->


### PR DESCRIPTION
The `tweeter` module currently crashes on startup if `HUBOT_TWEETER_ACCOUNTS` is unset, without a helpful message; I keep needing to reread the source to remember the variable name, which is especially unhelpful if I'm doing local development with the shell adapter. Here's the stack:

```
[Fri Jan 10 2014 08:51:38 GMT-0500 (EST)] ERROR Unable to load /home/ash/code/wheatley/node_modules/hubot-scripts/src/scripts/tweeter: SyntaxError: Unexpected token u
  at Object.parse (native)
  at Object.<anonymous> (/home/ash/code/wheatley/node_modules/hubot-scripts/src/scripts/tweeter.coffee:43:3, <js>:9:20)
  at Object.<anonymous> (/home/ash/code/wheatley/node_modules/hubot-scripts/src/scripts/tweeter.coffee:39:1, <js>:64:4)
  at Module._compile (module.js:456:26)
  at Object.loadFile (/home/ash/code/wheatley/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/coffee-script.js:182:19)
  at Module.load (/home/ash/code/wheatley/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/coffee-script.js:211:36)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Robot.loadFile (/home/ash/code/wheatley/node_modules/hubot/src/robot.coffee:214:9, <js>:161:11)
  at Robot.loadHubotScripts (/home/ash/code/wheatley/node_modules/hubot/src/robot.coffee:241:7, <js>:194:28)
  at /home/ash/code/wheatley/node_modules/hubot/bin/hubot:98:15, <js>:99:30
  at fs.js:266:14
  at Object.oncomplete (fs.js:107:15)
```

This PR ensures that `tweeter` checks the presence of the variable _before_ attempting to parse it, so you have a chance to see the warning, and defaults to an empty set of accounts.

It'll likely be obsoleted by #1179 and #1258; this is just a tiny patch to tide us over until the twitter auth is reworked.
