### PR TITLE
Pagerduty ack assigned

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -143,6 +143,9 @@ module.exports = (robot) ->
 
   robot.respond /(pager|major)( me)? ack(nowledge)?$/i, (msg) ->
     pagerDutyIncidents msg, 'triggered,acknwowledged', (incidents) ->
+      email  = msg.message.user.pagerdutyEmail || msg.message.user.email_address
+      incidents = incidentsForEmail(incidents, email)
+
       incidentNumbers = (incident.incident_number for incident in incidents)
       if incidentNumbers.length < 1
         msg.send "Nothing to acknowledge"
@@ -427,6 +430,10 @@ module.exports = (robot) ->
       incident.resolved_by_user.email
     else
       '(???)'
+
+  incidentsForEmail = (incidents, user_email) ->
+    incidents.filter (incident) ->
+      getUserForIncident(incident) == user_email
 
   generateIncidentString = (incident, hookType) ->
     console.log "hookType is " + hookType


### PR DESCRIPTION
This makes it so `hubot pager ack` only acks incidents assigned to your user. This minimizes the chances of acking something you didn't intend.

The real change in this PR is https://github.com/github/hubot-scripts/commit/328be7b3351018f488496c37c40f35a62723157f

The other commits are whitespace noise and cleanup.

/cc @github/ops-tools @github/ops 
