### PR TITLE
[hangout.coffee] tighten up regex to only match hangout and not hangout2 etc

### DIFF
--- a/src/scripts/hangout.coffee
+++ b/src/scripts/hangout.coffee
@@ -15,7 +15,7 @@
 #   nicoritschel
 
 module.exports = (robot) ->
-  robot.respond /hangout\s?(.*)?/i, (msg) ->
+  robot.respond /hangout\s.*/i, (msg) ->
     if process.env.HUBOT_HANGOUT_URL
       msg.send process.env.HUBOT_HANGOUT_URL
     else


### PR DESCRIPTION
I wanted to have 3 copies of this script that would each answer to `hangout`, `hangout2` and `hangout3`.
Problem was the current regex is not specific enough and was matching on all three.

This change tightens up the regex match to be more specific to allow people to run multiple copies.

after this PR I can then copy `node_modules/hubot-scripts/src/scripts/hangout.coffee` to `scripts/hangout2.coffee` and `scripts/hangout3.coffee` and modify the ENV_VARS accordingly.
