### PR TITLE
Added metric system forecasts to wunderground script

### DIFF
--- a/src/scripts/wunderground.coffee
+++ b/src/scripts/wunderground.coffee
@@ -88,10 +88,8 @@ get_data = (robot, msg, location, service, query, cb, lifetime, stack=0) ->
 
 send_forecast = (msg, location, data) ->
   report = data.forecast.txt_forecast.forecastday[0]
-  if not process.env.HUBOT_WUNDERGROUND_USE_METRIC?
-    msg.send "#{report.title} in #{location}: #{report.fcttext} (#{formatted_ttl data})"
-  else
-    msg.send "#{report.title} in #{location}: #{report.fcttext_metric} (#{formatted_ttl data})"
+  useMetric = process.env.HUBOT_WUNDERGROUND_USE_METRIC?
+  msg.send "#{report.title} in #{location}: #{if useMetric then report.fcttext_metric else report.fcttext} (#{formatted_ttl data})"
 send_radar = (msg, location, data) ->
   msg.send "#{data.radar.image_url}#.png"
 


### PR DESCRIPTION
Set the _HUBOT_WUNDERGROUND_USE_METRIC_ enviromental variable to arbitrary value to let hubot return the forecasts in metrical units like degree Celsius C°. Unset to return imperial units forecasts.
