### PR TITLE
Fix invalid array index generation in fml.coffee

### DIFF
--- a/src/scripts/fml.coffee
+++ b/src/scripts/fml.coffee
@@ -22,7 +22,7 @@ fml = (msg) ->
     .http('http://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=10&q=http://feeds.feedburner.com/fmylife')
       .get() (err, res, body) ->
         fmls = JSON.parse(body)
-        random = Math.round(Math.random() * fmls.responseData.feed.entries.length)
+        random = Math.floor(Math.random() * fmls.responseData.feed.entries.length)
         text = fmls.responseData.feed.entries[random].content
         text = text[0..text.indexOf('<img')-1]
         msg.send text


### PR DESCRIPTION
Swapped the usage of `Math.round` with `Math.floor` to prevent the generation of an invalid array index and subsequent exception.

Example:

Assume Math.random() returns `.9` and the array length is `5`.

`Math.round(.9 * 5)` yields `5`, exceeding the bounds of the array and triggers an exception.
`Math.floor(.9 * 5)` yields `4`, a valid index and the script works as expected.
