### PR TITLE
Make “it’s a trap” work with a proper apostrophe

### DIFF
--- a/src/scripts/ackbar.coffee
+++ b/src/scripts/ackbar.coffee
@@ -36,5 +36,5 @@ ackbars = [
 ]
 
 module.exports = (robot) ->
-  robot.hear /it('|’)?s a trap\b/i, (msg) ->
+  robot.hear /it['’]?s a trap\b/i, (msg) ->
     msg.send msg.random ackbars


### PR DESCRIPTION
slack.com has a habit of auto-converting ' into ’
