### PR TITLE
Allow a double-dash separator in messages without downgrading karma

### DIFF
--- a/src/scripts/karma.coffee
+++ b/src/scripts/karma.coffee
@@ -84,7 +84,7 @@ module.exports = (robot) ->
   karma = new Karma robot
   allow_self = process.env.KARMA_ALLOW_SELF or "true"
 
-  robot.hear /(\S+[^+:\s])[: ]*\+\+(\s|$)/, (msg) ->
+  robot.hear /(\S+[^+:\s])(: |:){0,1}\+\+(\s|$)/, (msg) ->
     subject = msg.match[1].toLowerCase()
     if allow_self is true or msg.message.user.name.toLowerCase() != subject
       karma.increment subject
@@ -92,7 +92,7 @@ module.exports = (robot) ->
     else
       msg.send msg.random karma.selfDeniedResponses(msg.message.user.name)
 
-  robot.hear /(\S+[^-:\s])[: ]*--(\s|$)/, (msg) ->
+  robot.hear /(\S+[^-:\s])(: |:){0,1}--(\s|$)/, (msg) ->
     subject = msg.match[1].toLowerCase()
     if allow_self is true or msg.message.user.name.toLowerCase() != subject
       karma.decrement subject


### PR DESCRIPTION
These should add and subtract karma:
```
  <thing>: ++
  <thing>++
  <thing>: --
  <thing>--
```

This should not downgrade Hubot's karma:
`Hubot -- is my favorite.`