### PR TITLE
Added REDIS_URL to support dokku

### DIFF
--- a/src/scripts/redis-brain.coffee
+++ b/src/scripts/redis-brain.coffee
@@ -5,7 +5,7 @@
 #   "redis": "0.8.4"
 #
 # Configuration:
-#   REDISTOGO_URL or REDISCLOUD_URL or BOXEN_REDIS_URL
+#   REDISTOGO_URL or REDISCLOUD_URL or BOXEN_REDIS_URL or REDIS_URL
 #
 # Commands:
 #   None
@@ -17,7 +17,7 @@ Url   = require "url"
 Redis = require "redis"
 
 module.exports = (robot) ->
-  info   = Url.parse process.env.REDISTOGO_URL or process.env.REDISCLOUD_URL or process.env.BOXEN_REDIS_URL or 'redis://localhost:6379'
+  info   = Url.parse process.env.REDISTOGO_URL or process.env.REDISCLOUD_URL or process.env.BOXEN_REDIS_URL or process.env.REDIS_URL or 'redis://localhost:6379'
   client = Redis.createClient(info.port, info.hostname)
 
   robot.brain.setAutoSave false


### PR DESCRIPTION
This environment variable is used by the Dokku Redis plugins to set the URL to get to the Redis instance in another Docker container. Adding this in allows people to self host their redis instance easily if they as using Dokku on their server.
