### PR TITLE
Improved email.coffee so it supports a wider array of transport methods

### DIFF
--- a/src/scripts/email.coffee
+++ b/src/scripts/email.coffee
@@ -2,34 +2,92 @@
 #   Email from hubot to any address
 #
 # Dependencies:
-#   None
+#   "nodemailer": "0.6.1"
 #
 # Configuration:
-#   None
+#   HUBOT_EMAIL_TRANSPORT - selected transport type (@see https://github.com/andris9/Nodemailer#possible-transport-methods)
+#   HUBOT_EMAIL_OPTIONS - JSON string of mail options (@see https://github.com/andris9/Nodemailer#possible-transport-methods)
+#   HUBOT_EMAIL_FROM - sender email address
 #
 # Commands:
 #   hubot email <user@email.com> -s <subject> -m <message> - Sends email with the <subject> <message> to address <user@email.com>
+#   hubot emailDebug <user@email.com> -s <subject> -m <message> - Operates the same as 'email', but provides detailed output for debugging configuration
+#
+# Notes:
+#   The above configuration and dependencies are only necessary if you don't have a unix mail client available
+#   or you want to use your own SMTP, SES or other service provided through 'nodemailer'. If you exclude the
+#   configuration above, it will default to the unix mail client.
 #
 # Author:
 #   earlonrails
+#   wintondeshong
 #
 # Additional Requirements
-#   unix mail client installed on the system
+#   unix mail client installed on the system (if you aren't using nodemailer)
 
 util = require 'util'
-child_process = require 'child_process'
+childProcess = require 'child_process'
+transportType = process.env.HUBOT_EMAIL_TRANSPORT
+nodemailerOptions = process.env.HUBOT_EMAIL_OPTIONS
+fromAddress = process.env.HUBOT_EMAIL_FROM
+isDebugMode = false
 
 module.exports = (robot) ->
   emailTime = null
-  sendEmail = (recipients, subject, msg, from) ->
-    mailArgs = ['-s', subject, '-a', "From: #{from}", '--']
-    mailArgs = mailArgs.concat recipients
-    p = child_process.execFile 'mail', mailArgs, {}, (error, stdout, stderr) ->
-      util.print 'stdout: ' + stdout
-      util.print 'stderr: ' + stderr
-    p.stdin.write "#{msg}\n"
-    p.stdin.end()
+
+  api =
+    msg: null
+
+    output: (standardMessage, debugDetails = null, isOnlyDebug = false) ->
+      if (not isDebugMode or not debugDetails?) and not isOnlyDebug
+        @msg.send standardMessage
+      if isDebugMode and debugDetails?
+        @msg.send "#{standardMessage}: #{util.inspect(debugDetails)}"
+
+    configureMailOptions: (recipients, subject, body, from) ->
+      return {
+        from: from
+        to: recipients.join ", "
+        subject: subject
+        text: body
+        html: body
+      }
+
+    sendNodeMail: (options) ->
+      mailerOptions = JSON.parse(nodemailerOptions)
+      @output 'Node Mailer Options', mailerOptions, true
+      transport = require('nodemailer').createTransport transportType, mailerOptions
+      @output 'Node Mailer Object', transport, true
+      @output 'Sending...'
+      transport.sendMail options, (error, response) =>
+        if error
+          @output 'Error delivering message', error
+        else
+          @output 'Message sent', response.message
+        transport.close()
+
+    sendUnixMail: (options) ->
+      mailArgs = ['-s', options.subject, '-a', "From: #{options.from}", '--']
+      mailArgs = mailArgs.concat options.recipients
+      p = childProcess.execFile 'mail', mailArgs, {}, (error, stdout, stderr) ->
+        util.print 'stdout: ' + stdout
+        util.print 'stderr: ' + stderr
+      p.stdin.write "#{options.body}\n"
+      p.stdin.end()
+      @output "Email sent"
+
+    sendEmail: (msg) ->
+      @msg = msg
+      mailMode = if transportType? then 'Node' else 'Unix'
+      from = if transportType? then fromAddress else msg.message.user.id
+      mailOptions = @configureMailOptions msg.match[1].split(' '), msg.match[2], msg.match[3], from
+      @output 'Mail Options', mailOptions, true
+      @["send#{mailMode}Mail"](mailOptions)
 
   robot.respond /email (.*) -s (.*) -m (.*)/i, (msg) ->
-    sendEmail msg.match[1].split(" "), msg.match[2], msg.match[3], msg.message.user.id
-    msg.send "email sent"
+    isDebugMode = false
+    api.sendEmail msg
+
+  robot.respond /emailDebug (.*) -s (.*) -m (.*)/i, (msg) ->
+    isDebugMode = true
+    api.sendEmail msg


### PR DESCRIPTION
Improved email.coffee so it supports a wider array of transport methods, html formatted emails, isn't coupled to the unix mailer, and provides configuration debugging capabilities. Ultimately, this allows the email script to function on a wider array of hosting environments.