### PR TITLE
Remove the At symbol when we check if the alias is valid

### DIFF
--- a/src/scripts/drush.coffee
+++ b/src/scripts/drush.coffee
@@ -126,7 +126,7 @@ drush_interface = ->
     site_alias = extra_args.shift()
     command_suff = ''
     if site_alias.charAt(0) is "@"
-      unless verify_alias(site_alias) is false
+      unless verify_alias(site_alias.slice(1)) is false
         command_suff = extra_args.shift()
       else
         `undefined`


### PR DESCRIPTION
The drush hubot implementation has a bug, before sending the alias to check if it is valid, it does not remove the "@" symbol.
This pull request fixes that.
