### PR TITLE
github-commit-link: Support user/repo@SHA and shorten response

### DIFF
--- a/src/scripts/github-commit-link.coffee
+++ b/src/scripts/github-commit-link.coffee
@@ -59,6 +59,6 @@ module.exports = (robot) ->
             url = commit_obj.url.replace(/api\./,'')
           url = url.replace(/repos\//,'')
           url = url.replace(/commits/,'commit')
-          msg.send "Commit: " + commit_obj.commit.message + " " + url
+          msg.send "Commit: " + commit_obj.commit.message.split("\n")[0] + "\n" + url
     else
       msg.send "Hey! You need to set HUBOT_GITHUB_REPO and HUBOT_GITHUB_TOKEN before I can link to that commit."


### PR DESCRIPTION
Details are in the commit messages themselves, but the support for
repo@<SHA> and user/repo@<SHA> is the most important to me.  Being
able to reference commits made in arbitrary GitHub projects makes it
easy to explain my motivation:

```
Jack: I don't understand why we need 123abcd
Jill: Because joe/widgets@9a8b7c6 broke compatibility with their old API
```
