### PR TITLE
Update jira-issues.coffee

### DIFF
--- a/src/scripts/jira-issues.coffee
+++ b/src/scripts/jira-issues.coffee
@@ -66,8 +66,12 @@ module.exports = (robot) ->
 
                   message = "[" + key + "] " + json.fields.summary
                   message += '\nStatus: '+json.fields.status.name
-                  if (json.fields.assignee and json.fields.assignee.displayName)
-                    message += ', assigned to ' + json.fields.assignee.displayName
+                  
+                  if ('value' of json.fields.assignee or 'displayName' of json.fields.assignee)
+                    if (json.fields.assignee.name == "assignee" and json.fields.assignee.value.displayName)
+                      message += ', assigned to ' + json.fields.assignee.value.displayName
+                    else if (json.fields.assignee and json.fields.assignee.displayName)
+                      message += ', assigned to ' + json.fields.assignee.displayName
                   else
                     message += ', unassigned'
                   message += ", rep. by "+json.fields.reporter.displayName


### PR DESCRIPTION
This change fixes a problem where unassigned tickets would result in "[_ERROR_] TypeError: Cannot read property '0' of undefined". Our copy of this file referred to the possibility of asignee properties being kept in json.fields.assignee.values rather than json.fields.assignee. Not sure if that was a custom changed that never ended up in a merge request or just a remnant of an older version. This change should be compatible with both possibilities either way.
