### PR TITLE
Add Em dash as alternative to decrease karma

### DIFF
--- a/src/scripts/karma.coffee
+++ b/src/scripts/karma.coffee
@@ -92,7 +92,7 @@ module.exports = (robot) ->
     else
       msg.send msg.random karma.selfDeniedResponses(msg.message.user.name)
 
-  robot.hear /(\S+[^-:\s])[: ]*--(\s|$)/, (msg) ->
+  robot.hear /(\S+[^-:\s])[: ]*(--|—)(\s|$)/, (msg) ->
     subject = msg.match[1].toLowerCase()
     if allow_self is true or msg.message.user.name.toLowerCase() != subject
       karma.decrement subject


### PR DESCRIPTION
Some clients like [Slack](https://slack.com/) replace the `--` in

```
wellle-- for writing hubot scripts
```

to an Em dash `—`

```
wellle— for writing hubot scripts
```

which doesn't get recognized in Hubot's karma script.

This pull requests decreases karma in the example above by triggering `karma.decrement` on Em dashes too.
