### PR TITLE
Will now respond if you spell the username in lower case

### DIFF
--- a/src/scripts/brb.coffee
+++ b/src/scripts/brb.coffee
@@ -24,7 +24,7 @@ module.exports = (robot) ->
 		else
 			for user, state of users_away
 				substr = msg.message.text.substring(0, user.length+1)
-				if substr == user + ':' or substr == user.toLowerCase() + ':'
+				if substr.toLowerCase() == user.toLowerCase() + ':'
 					msg.send user + " is currently away."
 					break
 		)


### PR DESCRIPTION
When you would mention the users name in the chat in lower case
you would get no response.

This solves the above issue, but dose not handle if the name
was mention in CAPS. I don't see the usage for yelling in chat so
I didn't include this.
