### PR TITLE
Return early for GitHub ping payloads (avoids error message in log)

### DIFF
--- a/src/scripts/github-commits.coffee
+++ b/src/scripts/github-commits.coffee
@@ -35,6 +35,7 @@ module.exports = (robot) ->
 
     try
       payload = JSON.parse req.body.payload
+      return if payload.zen? # initial ping
 
       if payload.commits.length > 0
         commitWord = if payload.commits.length > 1 then "commits" else "commit"


### PR DESCRIPTION
This eliminates the error message mentioned over in #1337. Specifically:

`github-commits error: TypeError: Cannot read property 'length' of undefined. Payload: {"zen":"It's not fully shipped until it's fast.","hook_id":1833128}`

The request works fine with or without this change, but this change eliminates the error from appearing in the Hubot logs.

(Fixes #1337)
