### PR TITLE
Allow specifying redis brain prefix

### DIFF
--- a/src/scripts/redis-brain.coffee
+++ b/src/scripts/redis-brain.coffee
@@ -5,25 +5,30 @@
 #   "redis": "0.8.4"
 #
 # Configuration:
-#   REDISTOGO_URL or REDISCLOUD_URL or BOXEN_REDIS_URL or REDIS_URL
+#   REDISTOGO_URL or REDISCLOUD_URL or BOXEN_REDIS_URL or REDIS_URL.
+#   URL format: redis://<host>:<port>[/<brain_prefix>]
+#   If not provided, '<brain_prefix>' will default to 'hubot'.
 #
 # Commands:
 #   None
 #
-# Author:
-#   atmos, jan0sch
+# Authors:
+#   atmos
+#   jan0sch
+#   spajus
 
 Url   = require "url"
 Redis = require "redis"
 
 module.exports = (robot) ->
-  info   = Url.parse process.env.REDISTOGO_URL or process.env.REDISCLOUD_URL or process.env.BOXEN_REDIS_URL or process.env.REDIS_URL or 'redis://localhost:6379'
+  info   = Url.parse process.env.REDISTOGO_URL or process.env.REDISCLOUD_URL or process.env.BOXEN_REDIS_URL or process.env.REDIS_URL or 'redis://localhost:6379/hubot', true
   client = Redis.createClient(info.port, info.hostname)
+  prefix = info.path.replace('/', '') or 'hubot'
 
   robot.brain.setAutoSave false
 
   getData = ->
-    client.get "hubot:storage", (err, reply) ->
+    client.get "#{prefix}:storage", (err, reply) ->
       if err
         throw err
       else if reply
@@ -51,7 +56,7 @@ module.exports = (robot) ->
     getData() if not info.auth
 
   robot.brain.on 'save', (data = {}) ->
-    client.set 'hubot:storage', JSON.stringify data
+    client.set "#{prefix}:storage", JSON.stringify data
 
   robot.brain.on 'close', ->
     client.quit()


### PR DESCRIPTION
Useful when hosting several hubot brains in one redis.
