### PR TITLE
Replace single space with double for readability.

### DIFF
--- a/src/scripts/ascii.coffee
+++ b/src/scripts/ascii.coffee
@@ -17,6 +17,6 @@ module.exports = (robot) ->
   robot.respond /ascii( me)? (.+)/i, (msg) ->
     msg
       .http("http://asciime.heroku.com/generate_ascii")
-      .query(s: msg.match[2])
+      .query(s: msg.match[2].split(' ').join('  '))
       .get() (err, res, body) ->
         msg.send body


### PR DESCRIPTION
Replacing all single spaces with double spaces.  The words were too close together and hard to read.
