### PR TITLE
removing space from message after custom username

### DIFF
--- a/src/scripts/chuck-norris.coffee
+++ b/src/scripts/chuck-norris.coffee
@@ -33,4 +33,4 @@ module.exports = (robot) ->
           if message_from_chuck.length == 0
             msg.send "Achievement unlocked: Chuck Norris is quiet!"
           else
-            msg.send message_from_chuck.value.joke
+            msg.send message_from_chuck.value.joke.replace /\s\s/g, " "


### PR DESCRIPTION
Since lastName param is empty API puts additional space after username.
