### PR TITLE
Update Janky Script setup Regex to accept template

### DIFF
--- a/src/scripts/janky.coffee
+++ b/src/scripts/janky.coffee
@@ -109,7 +109,7 @@ module.exports = (robot) ->
 
       msg.send response
 
-  robot.respond /ci setup ([\.\-\/_a-z0-9]+)(\s?([\.\-_a-z0-9]+))?/i, (msg) ->
+  robot.respond /ci setup ([\.\-\/_a-z0-9]+)(\s([\.\-_a-z0-9]+)(\s([\.\-_a-z0-9]+))?)?/i, (msg) ->
     nwo     = msg.match[1]
     params  = "?nwo=#{nwo}"
     if msg.match[3] != undefined


### PR DESCRIPTION
Janky Script had code for sending template, but not a regex that matched.

This fixes it and has been tested as working on our own hubot/janky setup
