### PR TITLE
Changed how indexing works when hn[id] is called

### DIFF
--- a/src/scripts/hackernews.coffee
+++ b/src/scripts/hackernews.coffee
@@ -50,7 +50,7 @@ module.exports = (robot) ->
          if element == "HN.top"
            idx = 0
          else
-           idx = (Number) msg.match[0].replace(/[^0-9]/g, '')
+           idx = (Number) msg.match[0].replace(/[^0-9]/g, '') - 1
          try
            item = feed.getItems()[idx]
            msg.send item.getTitle() + ": " + item.getPermalink() + " (" + item.getComments()?.html + ")"


### PR DESCRIPTION
The site has the indexing done so it starts from 1, and not 0. This makes quoting the actual Hacker News post a hassle because you have to always substract 1 to get the actual article link and title.

Eg.
![](http://puu.sh/80KIM/f3f05fd313.png)

And we before had to call the script using `hn[0]` to get the following response:

> EU top court rules EU data retention law invalid: http://www.reuters.com/article/2014/04/08/us-eu-data-ruling-idUSBREA370F020140408 (https://news.ycombinator.com/item?id=7552087)
