### PR TITLE
adding multiline support for memories by replacing `.` with `[\S\s]`

### DIFF
--- a/src/scripts/remember.coffee
+++ b/src/scripts/remember.coffee
@@ -24,7 +24,7 @@ module.exports = (robot) ->
 
   robot.respond /rem(?:ember)?\s+(.*)/i, (msg) ->
     words = msg.match[1]
-    if match = words.match /(.*?)(\s+is\s+(.*))$/i
+    if match = words.match /(.*?)(\s+is\s+([\s\S]*))$/i
       msg.finish()
       key = match[1].toLowerCase()
       value = match[3]


### PR DESCRIPTION
`[\S\s]` matching group is used to match new lines, since `.` doesnt match new lines in JavaScript's
implementation of RegEx
