### PR TITLE
Update graphite show command to allow for graphs that include spaces in ...

### DIFF
--- a/src/scripts/graphite.coffee
+++ b/src/scripts/graphite.coffee
@@ -30,7 +30,7 @@ module.exports = (robot) ->
       output = ""
       output += "#{human_id(metric)}\n" for metric in data
       msg.send output
-  robot.hear /graphite show (\S+)/i, (msg) ->
+  robot.hear /graphite show (.+)$/i, (msg) ->
     treeversal msg, (data) ->
       construct_url msg, data[0].graphUrl, (url) ->
         msg.send url


### PR DESCRIPTION
...their name

We have a couple of graphite graphs that have spaces in; current implementation means no matter what we search for, we only ever see the top matching graph;

i.e. we have:

```
alex.Top 100
alex.Top 5000
alex.Top Grouped By X
```

Performing a `graphite show Alex.Top Grouped By X` will always return `alex.Top 100`.

This fix solves that issue.
