### PR TITLE
Reddit Jokes: Always include title

### DIFF
--- a/src/scripts/reddit-jokes.coffee
+++ b/src/scripts/reddit-jokes.coffee
@@ -23,10 +23,8 @@ module.exports = (robot) ->
           children = data.data.children
           joke = msg.random(children).data
 
-          if joke.selftext.match /^\.\.\./
-            joketext = joke.title.replace(/\*\.\.\.$/,'') + ' ' + joke.selftext.replace(/^\.\.\.\s*/, '')
-          else
-            joketext = joke.selftext
+
+          joketext = joke.title.replace(/\*\.\.\.$/,'') + ' ' + joke.selftext.replace(/^\.\.\.\s*/, '')
 
           msg.send joketext.trim()
 


### PR DESCRIPTION
It seems to me that redditors do not always begin the text of the joke with ellipses like the script suggests they would. The joke almost always starts with the title of the joke. Therefore, we should always include it in hubot's output. Right now, half of the time that you ask hubot to 'joke me', all you get is a punch line. Though this is probably not an important script, it's driving me crazy and the fix seems easy. Please feel free to add questions or concerns. 
