### PR TITLE
When requesting a stream, lowercase both the request and the comparing...

### DIFF
--- a/src/scripts/graylog.coffee
+++ b/src/scripts/graylog.coffee
@@ -56,13 +56,15 @@ module.exports = (robot) ->
       msg.send what
 
 graylogStreamMessages = (msg, stream_title, count, cb) ->
+  stream_title = stream_title.toLowerCase()
   if stream_title == 'all'
     graylogMessages msg, 'messages.json', (messages) ->
       sayMessages messages, count, cb
   else
     graylogStreamList msg, (streams) ->
       for stream in streams
-        if stream.title == stream_title
+        lstream = stream.title.toLowerCase()
+        if lstream == stream_title
           url = "streams/#{stream._id}-#{stream.title}/messages.json"
           graylogMessages msg, url, (messages) ->
             sayMessages messages, count, cb


### PR DESCRIPTION
...stream so we can ignore case

Useful in cases where your streams are 'Warnings' and you type 'warnings'.
