### PR TITLE
Fixes earlier attempt to add the functionality to work with additional jsdom versions

### DIFF
--- a/src/scripts/http-info.coffee
+++ b/src/scripts/http-info.coffee
@@ -54,8 +54,21 @@ module.exports = (robot) ->
         else if title
           msg.send "#{title}"
 
+    versionCompare = (v1, v2, comparison) ->
+      v1parts = v1.split('.')
+      v2parts = v2.split('.')
+
+      for value1, i in v1parts
+        value1 = parseInt(value1, 10)
+        value2 = parseInt(v2parts[i], 10)
+        if comparison == '<' and value1 < value2
+          return 1
+        if comparison == '>' and value1 > value2
+          return 1
+      return 0
+
     unless ignore
-      if jsdom.version < '0.7.0'
+      if versionCompare jsdom.version, '0.7.0', '<'
         jsdom.env
           html: url
           scripts: [ jquery ]


### PR DESCRIPTION
Fixes what was attempted with commit 5f8a7bd7b9881307dd6c428106d597af68aebb83.  The problem with that code is that it is comparing two strings as if they are numbers, which does not work.  For instance, if your jsdom.version is '0.10.1' then it will evaluate in the code as 'less than' '0.7.0', make an incorrect call to jsdom.env and nothing will work.  I've added a quick and dirty, basic function to compare version number strings.  It can certainly be improved upon, but should work well enough.
