### PR TITLE
Add a basic script for querying Sourcing.io's API

### DIFF
--- a/src/scripts/sourcing-io.coffee
+++ b/src/scripts/sourcing-io.coffee
@@ -8,9 +8,9 @@
 #   SOURCING_IO_API_KEY
 #
 # Commands:
-#   hubot sourcing email <email address>
-#   hubot sourcing twitter <twitter handle>
-#   hubot sourcing github <github username>
+#   hubot sourcing --email <email address>
+#   hubot sourcing --twitter <twitter handle>
+#   hubot sourcing --github <github username>
 #
 # Notes:
 #   I'm lazy and won't implement a command for https://sourcing.io/api#people-search


### PR DESCRIPTION
This script allows Hubot to query the [sourcing.io API](https://sourcing.io/api).

For example, `hubot sourcing --twitter @alec_sloman` returns this message:

```
Alec Sloman
      Technical Recruiter at Lookahead Search
      located: Melbourne VIC, Australia
      languages: Not Coffeescript
      email: alec@lookahead.com.au
      score: 7.9
```

You can also search by `--email` address and `--github` username.

Ping @andrewk @xyfer - plz2 fix codes and implement all missing features. kthx

/cc @maccman your app only gave me a **7.9**. There is obviously something wrong with your algorithm. 
