### PR TITLE
Eval script sending wrong query

### DIFF
--- a/src/scripts/eval.coffee
+++ b/src/scripts/eval.coffee
@@ -55,7 +55,7 @@ module.exports = (robot) ->
       .get() (err, res, body) ->
         out = JSON.parse(body)
         ret = out.stdout or out.stderr
-        msg.send ret.split("\n")
+        msg.send ret
 
   robot.brain.on 'loaded', ->
     ready = true


### PR DESCRIPTION
The eval script sent the name of the language at the end of the hashbang of the generated script, not the command as it seems like it should. (i.e. it was sending `#!/usr/bin/py3` instead of `#!/usr/bin/python3.4`). This pull request takes care of that. It works at least with the pythons and bash, I haven't tested others.

This is likely a fix for #1384
