### PR TITLE
redis-brain: Check if info.path is null before replacing strings

### DIFF
--- a/src/scripts/redis-brain.coffee
+++ b/src/scripts/redis-brain.coffee
@@ -23,7 +23,7 @@ Redis = require "redis"
 module.exports = (robot) ->
   info   = Url.parse process.env.REDISTOGO_URL or process.env.REDISCLOUD_URL or process.env.BOXEN_REDIS_URL or process.env.REDIS_URL or 'redis://localhost:6379', true
   client = Redis.createClient(info.port, info.hostname)
-  prefix = info.path.replace('/', '') or 'hubot'
+  prefix = info.path?.replace('/', '') or 'hubot'
 
   robot.brain.setAutoSave false
 


### PR DESCRIPTION
Fixes the non-prefix case broken by #1383.

Until this lands, you can work around the error (discussed in
fdf19a3):

  ERROR Unable to load /.../redis-brain: TypeError: Cannot call method 'replace' of null

by ensuring REDIS_URL includes a trailing slash
(e.g. 'redis://localhost:6379/' instead of 'redis://localhost:6379').
