### PR TITLE
Deprecate tell.coffee -- it is a package of its own now

### DIFF
--- a/src/scripts/tell.coffee
+++ b/src/scripts/tell.coffee
@@ -1,3 +1,6 @@
+# THIS SCRIPT HAS MOVED TO ITS OWN PACKAGE. PLEASE USE
+# https://github.com/lorenzhs/hubot-tell INSTEAD!
+#
 # Description:
 #   Tell Hubot to send a user a message when present in the room
 #
@@ -14,6 +17,7 @@
 #   christianchristensen, lorenzhs, xhochy
 
 module.exports = (robot) ->
+   robot.logger.warning "tell.coffee has moved from hubot-scripts to its own package. See https://github.com/lorenzhs/hubot-tell/blob/master/UPGRADING.md for upgrade instructions"
    localstorage = {}
    robot.respond /tell ([\w.-]*):? (.*)/i, (msg) ->
      datetime = new Date()


### PR DESCRIPTION
Upgrade instructions at https://github.com/lorenzhs/hubot-tell/blob/master/UPGRADING.md

Also see https://github.com/hubot-scripts/packages/issues/50
