### PR TITLE
github-commits: Don't parse req.body (it's already an object)

### DIFF
--- a/src/scripts/github-commits.coffee
+++ b/src/scripts/github-commits.coffee
@@ -33,23 +33,23 @@ module.exports = (robot) ->
     user.room = query.room if query.room
     user.type = query.type if query.type
 
-    try
-      payload = JSON.parse req.body.payload
-      return if payload.zen? # initial ping
+    return if req.body.zen? # initial ping
+    push = req.body
 
-      if payload.commits.length > 0
-        commitWord = if payload.commits.length > 1 then "commits" else "commit"
-        robot.send user, "Got #{payload.commits.length} new #{commitWord} from #{payload.commits[0].author.name} on #{payload.repository.name}"
-        for commit in payload.commits
+    try
+      if push.commits.length > 0
+        commitWord = if push.commits.length > 1 then "commits" else "commit"
+        robot.send user, "Got #{push.commits.length} new #{commitWord} from #{push.commits[0].author.name} on #{push.repository.name}"
+        for commit in push.commits
           do (commit) ->
             gitio commit.url, (err, data) ->
               robot.send user, "  * #{commit.message} (#{if err then commit.url else data})"
       else
-        if payload.created
-          robot.send user, "#{payload.pusher.name} created: #{payload.ref}: #{payload.base_ref}"
-        if payload.deleted
-          robot.send user, "#{payload.pusher.name} deleted: #{payload.ref}"
+        if push.created
+          robot.send user, "#{push.pusher.name} created: #{push.ref}: #{push.base_ref}"
+        if push.deleted
+          robot.send user, "#{push.pusher.name} deleted: #{push.ref}"
 
     catch error
-      console.log "github-commits error: #{error}. Payload: #{req.body.payload}"
+      console.log "github-commits error: #{error}. Push: #{push}"
 


### PR DESCRIPTION
Avoid:

  github-commits error: SyntaxError: Unexpected token u. Payload: undefined

because req.body is already parsed by the time github-commits sees it. The
original github-commits code was added in 6e7ce2a (notify in chat when a new
commit is pushed, 2012-08-15), but Hubot added the bodyParser middleware in
github/hubot@4f4c8c7 (Use bodyParser middleware to parse POST bodys [sic], 2011-12-24), so
I'm not sure how this ever worked. From the express docs for req.body [1](http://expressjs.com/3x/api.html#req.body):

  This property is an object containing the parsed request body. This
 feature is provided by the bodyParser() middleware, though other
 body parsing middleware may follow this convention as well. This
 property defaults to {} when bodyParser() is used.

Besides removing the parsing, I've renamed the generic 'payload' to the more
specific 'push' for most of the script body, because
'req.body' is already a generic identifier, and I want to keep the parsed
variable isolated from future changes to the calling API.
