### PR TITLE
created http-status script that pulls from wikipedia

### DIFF
--- a/src/http-status.coffee
+++ b/src/http-status.coffee
@@ -1,0 +1,32 @@
+# Description:
+#   Displays the description for the requested error code.
+#
+# Dependencies:
+#   jsdom, jquery
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   hubot http status ###
+#
+# Author:
+#   delianides
+#
+
+jsdom = require "jsdom"
+jquery = 'http://ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js'
+
+module.exports = (robot) ->
+  robot.respond /http status (.*)/i, (msg) ->
+    httpCode = msg.match[1]
+    msg
+      .http('http://en.wikipedia.org/wiki/List_of_HTTP_status_codes')
+      .get() (err, res, body) ->
+        jsdom.env body, [jquery], (errors, window) ->
+          statusCode = window.$('#'+httpCode).parent().text()
+          if statusCode
+            msg.send statusCode
+            msg.send "http://en.wikipedia.org/wiki/List_of_HTTP_status_codes##{httpCode}"
+          else
+            msg.send "HTTP status code '#{httpCode}' doesn't exist. Ironically, this would be HTTP Error 404."


### PR DESCRIPTION
Simple hubot script so he can help you remember or discover HTTP status codes. 

```
hubot http status 404
```

Pulls data from this [wikipedia](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes) page.
