### PR TITLE
Remove Broken Beer Advocate Script

### DIFF
--- a/src/scripts/beeradvocate.coffee
+++ b/src/scripts/beeradvocate.coffee
@@ -17,10 +17,10 @@
 #   whyjustin
 
 module.exports = (robot) ->
-    robot.logger.warning "The beeradvocate script is deprecated and will not work (github/hubot-scripts#1436)."
+    robot.logger.warning "The beeradvocate script is broken and will not work (github/hubot-scripts#1436)."
 
     robot.respond /beer (a|advocate)( me)?/i, (msg) ->
-        msg.send "I'm sorry but beeradvocate is deprecated and will not work."
+        msg.send "I'm sorry but the beer advocate script is broken and will not work."
         # msg.http("http://beeradvocate.com/beer/")
         #     .get() (err, res, body) ->
         #         if (res.statusCode == 200)


### PR DESCRIPTION
I am the author of this script and am no longer maintaining it. It uses html scraping to gather information (beer advocate does not have an API) and the volatility of the website renders the script broken. Please remove as it will remain broken.

Thanks
