### PR TITLE
added replace stmnt so karma can be added to users with @ sign or just name

### DIFF
--- a/src/scripts/karma.coffee
+++ b/src/scripts/karma.coffee
@@ -85,7 +85,7 @@ module.exports = (robot) ->
   allow_self = process.env.KARMA_ALLOW_SELF or "true"
 
   robot.hear /(\S+[^+:\s])[: ]*\+\+(\s|$)/, (msg) ->
-    subject = msg.match[1].toLowerCase()
+    subject = (msg.match[1].replace /^.*@/g, "").toLowerCase()
     if allow_self is true or msg.message.user.name.toLowerCase() != subject
       karma.increment subject
       msg.send "#{subject} #{karma.incrementResponse()} (Karma: #{karma.get(subject)})"
@@ -93,7 +93,7 @@ module.exports = (robot) ->
       msg.send msg.random karma.selfDeniedResponses(msg.message.user.name)
 
   robot.hear /(\S+[^-:\s])[: ]*--(\s|$)/, (msg) ->
-    subject = msg.match[1].toLowerCase()
+    subject = (msg.match[1].replace /^.*@/g, "").toLowerCase()
     if allow_self is true or msg.message.user.name.toLowerCase() != subject
       karma.decrement subject
       msg.send "#{subject} #{karma.decrementResponse()} (Karma: #{karma.get(subject)})"
@@ -101,7 +101,7 @@ module.exports = (robot) ->
       msg.send msg.random karma.selfDeniedResponses(msg.message.user.name)
 
   robot.respond /karma empty ?(\S+[^-\s])$/i, (msg) ->
-    subject = msg.match[1].toLowerCase()
+    subject = (msg.match[1].replace /^.*@/g, "").toLowerCase()
     if allow_self is true or msg.message.user.name.toLowerCase() != subject
       karma.kill subject
       msg.send "#{subject} has had its karma scattered to the winds."


### PR DESCRIPTION
When some one gives karma to the default name format in hipchat `@name++` it adds karma to that string. So I made a change to remove the @ that way `@name++` and `name++` should both get have the same karma effects.
