### PR TITLE
Configuration documentation misleading

### DIFF
--- a/src/scripts/redis-brain.coffee
+++ b/src/scripts/redis-brain.coffee
@@ -6,7 +6,7 @@
 #
 # Configuration:
 #   REDISTOGO_URL or REDISCLOUD_URL or BOXEN_REDIS_URL or REDIS_URL.
-#   URL format: redis://<host>:<port>[/<brain_prefix>]
+#   URL format: redis://<host>:<port>/[<brain_prefix>]
 #   If not provided, '<brain_prefix>' will default to 'hubot'.
 #
 # Commands:


### PR DESCRIPTION
Using something like `redis://localhost:6379` instead of `redis://localhost:6379` will lead to `TypeError: Cannot call method 'replace' of null`
