### PR TITLE
Better logging for custom prefix

### DIFF
--- a/src/scripts/redis-brain.coffee
+++ b/src/scripts/redis-brain.coffee
@@ -35,7 +35,7 @@ module.exports = (robot) ->
         robot.logger.info "Data for #{prefix} brain retrieved from Redis"
         robot.brain.mergeData JSON.parse(reply.toString())
       else
-        robot.logger.info "Initializing new #{prefix} data for brain"
+        robot.logger.info "Initializing new data for #{prefix} brain"
         robot.brain.mergeData {}
 
       robot.brain.setAutoSave true


### PR DESCRIPTION
Useful when you have multiple Hubots accessing the same Redis server with different prefixes, so you can tell if it accessed/created the correct brain based on the env variable or default value, or other debugging.
