### PR TITLE
Fix error in github-pull-request-notifier when body is empty.

### DIFF
--- a/src/scripts/github-pull-request-notifier.coffee
+++ b/src/scripts/github-pull-request-notifier.coffee
@@ -50,7 +50,7 @@ module.exports = (robot) ->
 
 announcePullRequest = (data, cb) ->
   if data.action == 'opened'
-    mentioned = data.pull_request.body.match(/(^|\s)(@[\w\-\/]+)/g)
+    mentioned = data.pull_request.body?.match(/(^|\s)(@[\w\-\/]+)/g)
 
     if mentioned
       unique = (array) ->


### PR DESCRIPTION
When someone submits a pull request without a message the JSON document contains `null` for `body`. The notifier script was trying to call `match` on `body` to extract the list of user mentions. That would fail when it was `null`, resulting in:

```
Whoa, I got an error: TypeError: Cannot call method 'match' of null
```

This changes it to use the existential access operator, so when body is `null` the mention list is `undefined`.
