### PR TITLE
github-commits: Use res.send to respond to requests

### DIFF
--- a/src/scripts/github-commits.coffee
+++ b/src/scripts/github-commits.coffee
@@ -27,7 +27,7 @@ module.exports = (robot) ->
   robot.router.post "/hubot/gh-commits", (req, res) ->
     query = querystring.parse(url.parse(req.url).query)
 
-    res.end
+    res.send 200
 
     user = {}
     user.room = query.room if query.room


### PR DESCRIPTION
Instead of leaving folks hanging (which res.end without arguments seems to
do), use the higher-level res.send to send '200 OK' with the default body [1](http://expressjs.com/3x/api.html#res.send).
 With this commit, GitHub will know that the hook is working, and not report
'Service Timeout' in the hook's details page.

There are a number of other 'res.end' calls in other scripts, including a:

  res.end ""

call in github-pull-request-notifier.coffee (which seems to work), but I think
the higher-level interface and explicit clarity of:

  res.send 200

is more appropriate.

I didn't touch the 'res.end' calls in any other scripts, because the 
pull-request notifier seems to be working as is, and I haven't enabled the
other res.end-using scripts for testing.

Fixes #1454.
