### PR TITLE
Fixing zendesk.coffee since the API expects auth a little differently

### DIFF
--- a/src/scripts/zendesk.coffee
+++ b/src/scripts/zendesk.coffee
@@ -34,7 +34,7 @@ queries =
 zendesk_request = (msg, url, handler) ->
   zendesk_user = "#{process.env.HUBOT_ZENDESK_USER}"
   zendesk_password = "#{process.env.HUBOT_ZENDESK_PASSWORD}"
-  auth = new Buffer("#{zendesk_user}:#{zendesk_password}").toString('base64')
+  auth = new Buffer("#{zendesk_user}/#{zendesk_password}").toString('base64')
   zendesk_url = "https://#{process.env.HUBOT_ZENDESK_SUBDOMAIN}.zendesk.com/api/v2"
 
   msg.http("#{zendesk_url}/#{url}")


### PR DESCRIPTION
It's expecting a / instead of a : to separate auth/pass
