### PR TITLE
Add youtube-info command explanation

### DIFF
--- a/src/scripts/youtube-info.coffee
+++ b/src/scripts/youtube-info.coffee
@@ -8,7 +8,7 @@
 #   None
 #
 # Commands:
-#   None
+#   [YouTube video URL] - shows title and time length for the URL
 #
 # Notes:
 #   For text-based adapters like IRC.


### PR DESCRIPTION
This PR adds `youtube-info` command explanation, so that it shows up when using `hubot help`.
