### PR TITLE
pagerduty.coffee moved to it's own package

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -58,6 +58,8 @@ pagerRoom              = process.env.HUBOT_PAGERDUTY_ROOM
 pagerEndpoint          = process.env.HUBOT_PAGERDUTY_ENDPOINT || "/hook"
 
 module.exports = (robot) ->
+   robot.logger.warning "pagerduty.coffee has moved from hubot-scripts to its own package. See https://github.com/hubot-scripts/hubot-pager-me installation instructions"
+
   robot.respond /pager( me)?$/i, (msg) ->
     if missingEnvironmentForApi(msg)
       return


### PR DESCRIPTION
I've extracted this script to https://github.com/hubot-scripts/hubot-pager-me so it'd be a bit easier to manage adding people, releasing, refactoring, etc. I tried doing a filter-branch to extract and keep history, but had a tough time of it without having tons of empty merge commits :sweat: 

There's a few outstanding PRs that I'll see about porting over, with attribution cc https://github.com/github/hubot-scripts/pull/1458 https://github.com/github/hubot-scripts/pull/1280

cc previous contributors: @silas @gregone @ChrisLundquist @jacobbednarz  @streeter @jnewland @azizshamim 
