### PR TITLE
Fix github-merge to work against messages like `hubot merge github_user/repository/myfix into base`

### DIFF
--- a/src/scripts/github-merge.coffee
+++ b/src/scripts/github-merge.coffee
@@ -22,7 +22,7 @@ module.exports = (robot) ->
   github = require("githubot")(robot)
 
   # http://rubular.com/r/vnnwHvt75L
-  robot.respond /merge ([-_\.0-9a-zA-Z]+)(\/([-_\.a-zA-z0-9\/]+))? into ([-_\.a-zA-z0-9\/]+)$/i, (msg) ->
+  robot.respond /merge ([-_\.0-9a-zA-Z]+\/[-_\.0-9a-zA-Z]+)(\/([-_\.a-zA-z0-9\/]+))? into ([-_\.a-zA-z0-9\/]+)$/i, (msg) ->
     app      = msg.match[1]
     head     = msg.match[3] || "master"
     base     = msg.match[4]


### PR DESCRIPTION
I don't know how the original github-merge.coffee script is assumed to be used,
but to make Hubot merge pull requests on GitHub, I needed this change.

This fix changes the regex used from:

  http://rubular.com/r/GYTfo8swxd

To:

  http://rubular.com/r/ajwxmrfDZ4