### PR TITLE
Gerrit: accept search queries starting with '-'

### DIFF
--- a/src/scripts/gerrit.coffee
+++ b/src/scripts/gerrit.coffee
@@ -60,7 +60,7 @@ module.exports = (robot) ->
     robot.respond /gerrit (ignore|report)(?: me)? events for (project|user|event) (.+)/i, ignoreOrReportEventsMe robot, gerrit
 
 searchMe = (robot, gerrit) -> (msg) ->
-  cp.exec "ssh #{gerrit.hostname} -p #{gerrit.port} gerrit query --format=JSON #{msg.match[1]}", (err, stdout, stderr) ->
+  cp.exec "ssh #{gerrit.hostname} -p #{gerrit.port} gerrit query --format=JSON -- #{msg.match[1]}", (err, stdout, stderr) ->
     if err
       msg.send "Sorry, something went wrong talking with Gerrit: #{stderr}"
     else


### PR DESCRIPTION
Use the `--` argument to prevent gerrit from trying to parse query terms 
beginning with `-` as command line flags.

Example (shows all reviews that are open and have a change in the last hour):

```
hubot gerrit query status:open -age:1h
```
