### PR TITLE
Fixed the defprogramming script

### DIFF
--- a/src/scripts/capmetro.coffee
+++ b/src/scripts/capmetro.coffee
@@ -1,0 +1,36 @@
+# Description:
+#   Get arrival time of CapMetro buses (http://www.capmetro.org/)
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   hubot capmetro stopID - Get the schedule of the bus stop, with the stop's ID being stopID
+#
+# Author:
+#   Ricardo Cruz - @rkrdo
+
+module.exports = (robot) ->
+
+  robot.respond /capmetro (\d*)/i, (msg) ->
+
+    stopID = msg.match[1]
+    url = "http://www.capmetro.org/planner/s_nextbus2.asp?stopid=#{stopID}&opt=2"
+
+    msg.http(url)
+      .get() (err, res, body) ->
+        resp = JSON.parse(body)
+        if resp.status is "OK"
+          msg.send "Route: #{resp.routeDesc}"
+          msg.send "Stop: #{resp.stopDesc}"
+          for arrival, i in resp.list
+            do (arrival) ->
+              msg.send "Trip ##{i + 1}"
+              msg.send "\tScheduled Arrival: #{arrival.sched}"
+              msg.send "\tEstimated Arrival: #{arrival.est}"
+        else
+          msg.send "Stop with ID ##{stopID} wasn't found"
+

--- a/src/scripts/defprogramming.coffee
+++ b/src/scripts/defprogramming.coffee
@@ -19,12 +19,12 @@ HtmlParser = require "htmlparser"
 
 module.exports = (robot) ->
     robot.respond /def programming/i, (msg) ->
-        msg.http("http://www.defprogramming.com/random")
+        msg.http("http://www.defprogramming.com/random/")
            .get() (err, res, body) ->
                handler = new HtmlParser.DefaultHandler()
                parser  = new HtmlParser.Parser handler
 
                parser.parseComplete body
 
-               results = Select handler.dom, "cite a p"
+               results = Select handler.dom, "q.jumbotron p"
                msg.send results[0].children[0].raw


### PR DESCRIPTION
the [defprogramming](http://defprogramming.com/) website changed it's design so the script wasn't working. 
Also, making the request to `http://defprogramming.com/random` (without the trailing slash) returned a 301
```
HTTP/1.1 301 Moved Permanently
Server: Apache/2.2.17 (Ubuntu)
Content-Type: text/html; charset=utf-8
Location: http://defprogramming.com/random/
Vary: Accept-Encoding
X-Cacheable: YES
Content-Length: 0
Date: Fri, 01 Aug 2014 01:17:19 GMT
X-Varnish: 1295976573
Age: 0
Via: 1.1 varnish
Connection: close
X-Cache: MISS
```

The fix was adding a slash at the end of the url `http://defprogramming.com/random/`