### PR TITLE
Allowed Chess to be channel/room independant

### DIFF
--- a/src/scripts/chess.coffee
+++ b/src/scripts/chess.coffee
@@ -20,12 +20,12 @@ Chess = require 'chess'
 
 module.exports = (robot) ->
   robot.respond /chess me$/i, (msg) ->
-    robot.brain.data.chess = Chess.create()
-    boardToFen robot.brain.data.chess.getStatus(), (status, fen) ->
+    robot.brain.data.chess[msg.message.room] = Chess.create()
+    boardToFen robot.brain.data.chess[msg.message.room].getStatus(), (status, fen) ->
       msg.send 'http://webchess.freehostia.com/diag/chessdiag.php?fen=' + encodeURIComponent(fen) + '&size=large&coord=yes&cap=yes&stm=yes&fb=no&theme=classic&format=auto&color1=E3CEAA&color2=635147&color3=000000&.png'
   robot.respond /chess status/i, (msg) ->
     try
-      boardToFen robot.brain.data.chess.getStatus(), (status, fen) ->
+      boardToFen robot.brain.data.chess[msg.message.room].getStatus(), (status, fen) ->
         if status
           msg.send status
         msg.send 'http://webchess.freehostia.com/diag/chessdiag.php?fen=' + encodeURIComponent(fen) + '&size=large&coord=yes&cap=yes&stm=yes&fb=no&theme=classic&format=auto&color1=E3CEAA&color2=635147&color3=000000&.png'
@@ -34,8 +34,8 @@ module.exports = (robot) ->
 
   robot.respond /chess move (.*)/i, (msg) ->
     try
-      robot.brain.data.chess.move msg.match[1]
-      boardToFen robot.brain.data.chess.getStatus(), (status, fen) ->
+      robot.brain.data.chess[msg.message.room].move msg.match[1]
+      boardToFen robot.brain.data.chess[msg.message.room].getStatus(), (status, fen) ->
        if status
           msg.send status
         msg.send 'http://webchess.freehostia.com/diag/chessdiag.php?fen=' + encodeURIComponent(fen) + '&size=large&coord=yes&cap=yes&stm=yes&fb=no&theme=classic&format=auto&color1=E3CEAA&color2=635147&color3=000000&.png'


### PR DESCRIPTION
The previous script only allowed one game to be run per bot. This simply stores the chess games in a store relative to the channel name, allowing multiple games to be run at one time.