### PR TITLE
Print issue and merge request's id and issue's url

### DIFF
--- a/src/scripts/gitlab.coffee
+++ b/src/scripts/gitlab.coffee
@@ -88,7 +88,7 @@ module.exports = (robot) ->
         else
           switch hook.object_kind
             when "issue"
-              robot.send user, "Issue #{bold(hook.object_attributes.iid)}: #{hook.object_attributes.title} (#{hook.object_attributes.state})"
+              robot.send user, "Issue #{bold(hook.object_attributes.iid)}: #{hook.object_attributes.title} (#{hook.object_attributes.state}) at #{hook.object_attributes.url}"
             when "merge_request"
               robot.send user, "Merge Request #{bold(hook.object_attributes.iid)}: #{hook.object_attributes.title} (#{hook.object_attributes.state}) between #{bold(hook.object_attributes.source_branch)} and #{bold(hook.object_attributes.target_branch)}"
           if hook.object_attributes.description


### PR DESCRIPTION
GitLab Issue's Webhook includes issue's URL ( but, merge request's isn't included ).

It can print issue's URL.

And, original script print id which is not id in project. It is total id.

So, I think it's better.
