### PR TITLE
Mark auth.coffee as deprecated

### DIFF
--- a/src/scripts/auth.coffee
+++ b/src/scripts/auth.coffee
@@ -25,6 +25,8 @@
 #   alexwilliamsca
 
 module.exports = (robot) ->
+  robot.logger.warning "auth.coffee has moved from hubot-scripts to its own package. See https://github.com/hubot-scripts/hubot-auth installation instructions"
+
   admin = process.env.HUBOT_AUTH_ADMIN
 
   class Auth


### PR DESCRIPTION
To avoid confusion with the generated `auth.coffee` and `hubot-auth`, prefer `hubot-auth` instead.

cc https://github.com/github/hubot/pull/656 for discussion
