### PR TITLE
Add word boundary to zen.coffee

### DIFF
--- a/src/scripts/zen.coffee
+++ b/src/scripts/zen.coffee
@@ -15,7 +15,7 @@
 #
 
 module.exports = (robot) ->
-  robot.hear /\b(zen)\b/i, (msg) ->
+  robot.hear /\bzen\b/i, (msg) ->
     msg
       .http("https://api.github.com/zen")
       .get() (err, res, body) ->


### PR DESCRIPTION
In my team's Slack chat, we've found the zen script to be a bit annoying, matching words like "dozens" or "citizen". I added a word boundary to prevent this from happening.
