### PR TITLE
Fix github org-pulls command.

### DIFF
--- a/src/scripts/github-pulls.coffee
+++ b/src/scripts/github-pulls.coffee
@@ -65,7 +65,7 @@ module.exports = (robot) ->
       msg.send "No organization specified, please provide one or set HUBOT_GITHUB_ORG accordingly."
       return
 
-    url = "#{url_api_base}/orgs/#{org_name}/issues?filter=all&state=open"
+    url = "#{url_api_base}/orgs/#{org_name}/issues?filter=all&state=open&per_page=100"
     github.get url, (issues) ->
       if issues.length == 0
         summary = "Achievement unlocked: open pull requests zero!"


### PR DESCRIPTION
The GitHub org-pulls command `hubot show org-pulls` was not working properly for me; this PR fixes the problem(s) i was experiencing.

The org-pulls command works by first requesting all GitHub organisation issues and then filters them down to ones that are pull requests.

I updated the way issues are filtered; since the GitHub API does not return the pull_request object for non pull request issues, checking `issue.pull_request.html_url == null` would throw an error (trying to read html_url of undefined) for all non pull request issue objects. This updated loop/conditional adds the issue to the filtered_result if the pull_request property exists.

I also restricted the issues API request to return only open issues (for performance gains).
