### PR TITLE
github-commits: Add ability to filter out tag/branch creation messages

### DIFF
--- a/src/scripts/github-commits.coffee
+++ b/src/scripts/github-commits.coffee
@@ -8,6 +8,7 @@
 #
 # Configuration:
 #   Just put this url <HUBOT_URL>:<PORT>/hubot/gh-commits?room=<room> into you'r github hooks
+#   HUBOT_GITHUB_COMMITS_ONLY -- Only report pushes with commits. Ignores creation of tags and branches.
 #
 # Commands:
 #   None
@@ -44,7 +45,7 @@ module.exports = (robot) ->
           do (commit) ->
             gitio commit.url, (err, data) ->
               robot.send user, "  * #{commit.message} (#{if err then commit.url else data})"
-      else
+      else if !process.env.HUBOT_GITHUB_COMMITS_ONLY
         if push.created
           if push.base_ref
             robot.send user, "#{push.pusher.name} created: #{push.ref}: #{push.base_ref}"

--- a/src/scripts/github-commits.coffee
+++ b/src/scripts/github-commits.coffee
@@ -46,7 +46,10 @@ module.exports = (robot) ->
               robot.send user, "  * #{commit.message} (#{if err then commit.url else data})"
       else
         if push.created
-          robot.send user, "#{push.pusher.name} created: #{push.ref}: #{push.base_ref}"
+          if push.base_ref
+            robot.send user, "#{push.pusher.name} created: #{push.ref}: #{push.base_ref}"
+          else
+            robot.send user, "#{push.pusher.name} created: #{push.ref}"
         if push.deleted
           robot.send user, "#{push.pusher.name} deleted: #{push.ref}"
 


### PR DESCRIPTION
Added optional HUBOT_GITHUB_COMMITS_ONLY env variable that will restrict messages to pushes with commits and filter out the creation/deletion of tags and branches. Handy if you have an automated build system creating a lot of tags.
Also, conditionally add base_ref to message if it is specified. It can be undefined.