### PR TITLE
tell: Update repository URL to organisation repo

### DIFF
--- a/src/scripts/tell.coffee
+++ b/src/scripts/tell.coffee
@@ -1,5 +1,5 @@
 # THIS SCRIPT HAS MOVED TO ITS OWN PACKAGE. PLEASE USE
-# https://github.com/lorenzhs/hubot-tell INSTEAD!
+# https://github.com/hubot-scripts/hubot-tell INSTEAD!
 #
 # Description:
 #   Tell Hubot to send a user a message when present in the room
@@ -17,7 +17,7 @@
 #   christianchristensen, lorenzhs, xhochy
 
 module.exports = (robot) ->
-   robot.logger.warning "tell.coffee has moved from hubot-scripts to its own package. See https://github.com/lorenzhs/hubot-tell/blob/master/UPGRADING.md for upgrade instructions"
+   robot.logger.warning "tell.coffee has moved from hubot-scripts to its own package. See https://github.com/hubot-scripts/hubot-tell/blob/master/UPGRADING.md for upgrade instructions"
    localstorage = {}
    robot.respond /tell ([\w.-]*):? (.*)/i, (msg) ->
      datetime = new Date()


### PR DESCRIPTION
The `hubot-tell` repo has moved to the `hubot-scripts` organisation, refect this change in the link to the upgrading guide.

Old repo: https://github.com/lorenzhs/hubot-tell
New repo: https://github.com/hubot-scripts/hubot-tell
