### PR TITLE
fix isup to handle http://domain.com case

### DIFF
--- a/src/scripts/isup.coffee
+++ b/src/scripts/isup.coffee
@@ -14,8 +14,8 @@
 #   jmhobbs
 
 module.exports = (robot) ->
-  robot.respond /is (http\:\/\/)?(.*?) (up|down)(\?)?/i, (msg) ->
-    isUp msg, msg.match[2], (domain) ->
+  robot.respond /is (?:http\:\/\/)?(.*?) (up|down)(\?)?/i, (msg) ->
+    isUp msg, msg.match[1], (domain) ->
       msg.send domain
 
 isUp = (msg, domain, cb) ->


### PR DESCRIPTION
When we use hubot with irc adaptor and slack, slack automatically inject http:// in front of urls. In this case, isup does not work properly. This PR is to fix it.
