### PR TITLE
Remove enclosing brackets around gitlab push notifiers

### DIFF
--- a/src/scripts/gitlab.coffee
+++ b/src/scripts/gitlab.coffee
@@ -12,7 +12,7 @@
 #   Put http://<HUBOT_URL>:<PORT>/gitlab/system as your system hook
 #   Put http://<HUBOT_URL>:<PORT>/gitlab/web as your web hook (per repository)
 #   You can also append "?targets=%23room1,%23room2" to the URL to control the
-#   message destination.  Using the "target" parameter to override the 
+#   message destination.  Using the "target" parameter to override the
 #   GITLAB_CHANNEL configuration value.
 #
 # Commands:
@@ -80,9 +80,9 @@ module.exports = (robot) ->
           branch = hook.ref.split("/")[2..].join("/")
           # if the ref before the commit is 00000, this is a new branch
           if /^0+$/.test(hook.before)
-            message = "#{bold(hook.user_name)} pushed a new branch (#{bold(branch)}) to #{bold(hook.repository.name)} (#{underline(hook.repository.homepage)})"
+            message = "#{bold(hook.user_name)} pushed a new branch (#{bold(branch)}) to #{bold(hook.repository.name)} #{underline(hook.repository.homepage)}"
           else
-            message = "#{bold(hook.user_name)} pushed #{bold(hook.total_commits_count)} commits to #{bold(branch)} in #{bold(hook.repository.name)} (#{underline(hook.repository.homepage + '/compare/' + hook.before.substr(0,9) + '...' + hook.after.substr(0,9))})"
+            message = "#{bold(hook.user_name)} pushed #{bold(hook.total_commits_count)} commits to #{bold(branch)} in #{bold(hook.repository.name)} #{underline(hook.repository.homepage + '/compare/' + hook.before.substr(0,9) + '...' + hook.after.substr(0,9))}"
           robot.send user, message
         # not code? must be a something good!
         else


### PR DESCRIPTION
The presence of the brackets is inconsistent with the rest of the
messages, and in some services it causes the residing url to break (as
the closing parenthesis is seen as part of the url)
