### PR TITLE
Handle 404 errors

### DIFF
--- a/src/scripts/jenkins.coffee
+++ b/src/scripts/jenkins.coffee
@@ -61,7 +61,7 @@ jenkinsBuild = (msg, buildWithEmptyParameters) ->
         else if 400 == res.statusCode
           jenkinsBuild(msg, true)
         else if 404 == res.statusCode
-          msg.reply "Build not found"
+          msg.reply "Build not found, double check that it exists and is spelt correctly."
         else
           msg.reply "Jenkins says: Status #{res.statusCode} #{body}"
 

--- a/src/scripts/jenkins.coffee
+++ b/src/scripts/jenkins.coffee
@@ -60,6 +60,8 @@ jenkinsBuild = (msg, buildWithEmptyParameters) ->
           msg.reply "(#{res.statusCode}) Build started for #{job} #{url}/job/#{job}"
         else if 400 == res.statusCode
           jenkinsBuild(msg, true)
+        else if 404 == res.statusCode
+          msg.reply "Build not found"
         else
           msg.reply "Jenkins says: Status #{res.statusCode} #{body}"
 


### PR DESCRIPTION
Currently if you request a non-existent project be built (normally due to a typo) it spews large quantities of ugly HTML into the channel.  This commit makes it handle 404s with a 1 line response instead.