### PR TITLE
Fix title/description functionality

### DIFF
--- a/src/scripts/http-info.coffee
+++ b/src/scripts/http-info.coffee
@@ -45,8 +45,8 @@ module.exports = (robot) ->
     done = (errors, window) ->
       unless errors
         $ = window.$
-        title = $('title').first().text().replace(/(\r\n|\n|\r)/gm,'').replace(/\s{2,}/g,' ').trim()
-        description = $('meta[name=description]').first().attr('content').replace(/(\r\n|\n|\r)/gm,'').replace(/\s{2,}/g,' ').trim() || ''
+        title = $('head title').text().replace(/(\r\n|\n|\r)/gm,'').replace(/\s{2,}/g,' ').trim()
+        description = $('head meta[name=description]').attr('content').replace(/(\r\n|\n|\r)/gm,'').replace(/\s{2,}/g,' ').trim() || ''
 
         if title and description and not process.env.HUBOT_HTTP_INFO_IGNORE_DESC
           msg.send "#{title}\n#{description}"


### PR DESCRIPTION
Only get the first title/description, remove all newlines, remove all superfluous white space.

In an ideal world this would not be necessary but many sites have newlines/spaces in their titles. At the time of writing ello.co has 83 title tags on its home page - most of which are in the body.

![titlefail](https://cloud.githubusercontent.com/assets/1583854/4489407/acebaaa4-4a1a-11e4-90dd-ad0ac574879f.png)
