### PR TITLE
rsstodolist.coffee : put some space between links...

### DIFF
--- a/src/scripts/rsstodolist.coffee
+++ b/src/scripts/rsstodolist.coffee
@@ -54,7 +54,7 @@ module.exports = (robot) ->
 
                   reply += " - #{title},"
                   reply += " #{description}" if description?
-                  reply += " [#{link}]\n"
+                  reply += " [ #{link} ]\n"
             catch err
                   msg.reply err
 


### PR DESCRIPTION
Sometimes, browser will include "]" character in links, forcing user to
remove it manually. Adding space should prevent that.
