### PR TITLE
gitlab: Add space around URL in parenthesis

### DIFF
--- a/src/scripts/gitlab.coffee
+++ b/src/scripts/gitlab.coffee
@@ -82,7 +82,7 @@ module.exports = (robot) ->
           if /^0+$/.test(hook.before)
             message = "#{bold(hook.user_name)} pushed a new branch (#{bold(branch)}) to #{bold(hook.repository.name)} #{underline(hook.repository.homepage)}"
           else
-            message = "#{bold(hook.user_name)} pushed to #{branch} at #{hook.repository.name} (#{underline(hook.repository.homepage + '/compare/' + hook.before.substr(0,9) + '...' + hook.after.substr(0,9))})"
+            message = "#{bold(hook.user_name)} pushed to #{branch} at #{hook.repository.name} #{underline(hook.repository.homepage + '/compare/' + hook.before.substr(0,9) + '...' + hook.after.substr(0,9))}"
             message += "\n" + hook.commits.map((commit) -> commit.message).join("\n")
           robot.send user, message
         # not code? must be a something good!


### PR DESCRIPTION
Unfortunately many url matching parsers tend to get tricked by the closing ) - which means when you click the link you end up with a broken link with ')' appended to it.

By adding some space we avoid this.
