### PR TITLE
Added support for multiple actions

### DIFF
--- a/src/scripts/eardropping.coffee
+++ b/src/scripts/eardropping.coffee
@@ -1,6 +1,7 @@
 # Description:
 #   Add programmable interface to hubot.  Allow to run a hubot command
-#   whenever something came up in the conversation.
+#   whenever something came up in the conversation. Optionally, multiple 
+#   actions can be specified, with or without ordering.
 #
 # Dependencies:
 #   None
@@ -10,6 +11,7 @@
 #
 # Commands:
 #   hubot when you hear <pattern> do <something hubot does> - Setup a ear dropping event
+#   hubot when you hear <pattern> do 1|<something hubot does>; 2|<some.... - Set up ear dropping with multiple actions and ordering
 #   hubot stop ear dropping - Stop all ear dropping
 #   hubot stop ear dropping on <pattern> - Remove a particular ear dropping event
 #   hubot show ear dropping - Show what hubot is ear dropping on
@@ -25,8 +27,8 @@ class EarDropping
     @robot.brain.on 'loaded', =>
       if @robot.brain.data.eardropping
         @cache = @robot.brain.data.eardropping
-  add: (pattern, action) ->
-    task = {key: pattern, task: action}
+  add: (pattern, action, order) ->
+    task = {key: pattern, task: action, order: order}
     @cache.push task
     @robot.brain.data.eardropping = @cache
   all: -> @cache
@@ -42,8 +44,9 @@ module.exports = (robot) ->
 
   robot.respond /when you hear (.+?) do (.+?)$/i, (msg) ->
     key = msg.match[1]
-    task = msg.match[2]
-    earDropping.add(key, task)
+    for task_raw in msg.match[2].split ";"
+      task_split = task_raw.split "|"
+      earDropping.add(key, task_split[1], task_split[0])
     msg.send "I am now ear dropping for #{key}. Hehe."
 
   robot.respond /stop ear *dropping$/i, (msg) ->
@@ -64,7 +67,20 @@ module.exports = (robot) ->
   robot.hear /(.+)/i, (msg) ->
     robotHeard = msg.match[1]
 
-    for task in earDropping.all()
+    tasks = earDropping.all()
+    tasks.sort (a,b) ->
+      return if a.order >= b.order then 1 else -1
+
+    console.log "Tasks: #{tasks}"
+    tasksToRun = []
+
+    for task in tasks
       if new RegExp(task.key, "i").test(robotHeard)
-        if (robot.name != msg.message.user.name && !(new RegExp("^#{robot.name}", "i").test(robotHeard)))
-          robot.receive new TextMessage(msg.message.user, "#{robot.name}: #{task.task}")
+        tasksToRun.push task
+
+    tasksToRun.sort (a,b) ->
+      return if a.order >= b.order then 1 else -1
+
+    for task in tasksToRun
+      if (robot.name != msg.message.user.name && !(new RegExp("^#{robot.name}", "i").test(robotHeard)))
+        robot.receive new TextMessage(msg.message.user, "#{robot.name}: #{task.task}")

--- a/src/scripts/eardropping.coffee
+++ b/src/scripts/eardropping.coffee
@@ -71,9 +71,7 @@ module.exports = (robot) ->
     tasks.sort (a,b) ->
       return if a.order >= b.order then 1 else -1
 
-    console.log "Tasks: #{tasks}"
     tasksToRun = []
-
     for task in tasks
       if new RegExp(task.key, "i").test(robotHeard)
         tasksToRun.push task


### PR DESCRIPTION
We wanted to be able to trigger multiple events in a sequence with eardropping but the existing implementation would trigger events in an almost random order. Added an order parameter to the task object and set up a bit to sort tasks that match the current eardrop trigger. I'm quite new to coffeescript and hubot programming so there's probably some room to refactor my additions.

The ordering still isn't 100% accurate. Hubot will trigger the tasks in the correct sequence but target actions may appear to the user out of order. For example, when hubot hears "kaboom" it should trigger "how many days since kaboom?", then echo <url to a gif> and finally reset the days since kaboom counter to 0. On the server side, this executes in the desired order but on client side, those messages might be received out of sequence.