### PR TITLE
Avoid redirect by adding www to the URL

### DIFF
--- a/src/scripts/clojure.coffee
+++ b/src/scripts/clojure.coffee
@@ -19,7 +19,7 @@ module.exports = (robot) ->
   robot.respond /(clojure|clj)\s+(.*)/i, (msg)->
     script = msg.match[2]
 
-    msg.http("http://tryclj.com/eval.json")
+    msg.http("http://www.tryclj.com/eval.json")
       .query(expr: script)
       .headers(Cookie: "ring-session=#{ringSessionID}")
       .get() (err, res, body) ->


### PR DESCRIPTION
Currently, the script is not working because the server is responding with a redirect to the home page, when the www is not specified.
