### PR TITLE
Avoid adding a loose ] onto the weblink inserted on Log - Janky script

### DIFF
--- a/src/scripts/janky.coffee
+++ b/src/scripts/janky.coffee
@@ -41,7 +41,7 @@ buildStatusMessage = (build) ->
   response = ""
   response += "Build ##{build.number} (#{build.sha1}) of #{build.repo}/#{build.branch} #{build.status}"
   response += "(#{build.duration}s) #{build.compare}"
-  response += " [Log: #{build.web_url}]"
+  response += " [Log: #{build.web_url} ]"
 
 
 get = (path, params, cb) ->


### PR DESCRIPTION
Currently the response for status updates appends a ] to the link, making the link invalid.
