### PR TITLE
Don't assume that webpages have meta tags with descriptions.

### DIFF
--- a/src/scripts/http-info.coffee
+++ b/src/scripts/http-info.coffee
@@ -46,7 +46,7 @@ module.exports = (robot) ->
       unless errors
         $ = window.$
         title = $('head title').text().replace(/(\r\n|\n|\r)/gm,'').replace(/\s{2,}/g,' ').trim()
-        description = $('head meta[name=description]').attr('content').replace(/(\r\n|\n|\r)/gm,'').replace(/\s{2,}/g,' ').trim() || ''
+        description = $('head meta[name=description]')?.attr('content')?.replace(/(\r\n|\n|\r)/gm,'')?.replace(/\s{2,}/g,' ')?.trim() || ''
 
         if title and description and not process.env.HUBOT_HTTP_INFO_IGNORE_DESC
           msg.send "#{title}\n#{description}"


### PR DESCRIPTION
This fixes a crash on http-info.coffee as many web pages don't have this meta tag.