### PR TITLE
Switching from robot.respond to robot.hear for Jira issues

### DIFF
--- a/src/scripts/jira.coffee
+++ b/src/scripts/jira.coffee
@@ -185,7 +185,7 @@ module.exports = (robot) ->
     search msg, msg.match[2], (text) ->
       msg.reply text
   
-  robot.respond /([^\w\-]|^)(\w+-[0-9]+)(?=[^\w]|$)/ig, (msg) ->
+  robot.hear /([^\w\-]|^)(\w+-[0-9]+)(?=[^\w]|$)/ig, (msg) ->
     if msg.message.user.id is robot.name
       return
 


### PR DESCRIPTION
The documentation for this script indicates that the robot will respond
to any Jira ticket found in chat. That was changed in commit 4c82425, which
has a number of comments on it requesting the change be reverted.

There are at least three things in the code that should prevent the bot from
looping on Jira issues - HUBOT_JIRA_IGNOREUSERS, the recent issue cache, and
the line to detect hubot's own name. This script is a lot more useful if the
bot responds to any Jira issues, rather than just ones addressed to it.