### PR TITLE
removing actual ship image

### DIFF
--- a/src/scripts/shipit.coffee
+++ b/src/scripts/shipit.coffee
@@ -22,7 +22,6 @@ squirrels = [
   "http://images.cheezburger.com/completestore/2011/11/2/46e81db3-bead-4e2e-a157-8edd0339192f.jpg",
   "http://28.media.tumblr.com/tumblr_lybw63nzPp1r5bvcto1_500.jpg",
   "http://i.imgur.com/DPVM1.png",
-  "http://gifs.gifbin.com/092010/1285616410_ship-launch-floods-street.gif",
   "http://d2f8dzk2mhcqts.cloudfront.net/0772_PEW_Roundup/09_Squirrel.jpg",
   "http://www.cybersalt.org/images/funnypictures/s/supersquirrel.jpg",
   "http://www.zmescience.com/wp-content/uploads/2010/09/squirrel.jpg",

--- a/src/scripts/shipit.coffee
+++ b/src/scripts/shipit.coffee
@@ -17,7 +17,6 @@
 #   maddox
 
 squirrels = [
-  "https://img.skitch.com/20111026-r2wsngtu4jftwxmsytdke6arwd.png",
   "http://images.cheezburger.com/completestore/2011/11/2/aa83c0c4-2123-4bd3-8097-966c9461b30c.jpg",
   "http://images.cheezburger.com/completestore/2011/11/2/46e81db3-bead-4e2e-a157-8edd0339192f.jpg",
   "http://28.media.tumblr.com/tumblr_lybw63nzPp1r5bvcto1_500.jpg",


### PR DESCRIPTION
Am a huge fan of the 'ship it' images but the one that seems out of place is the ship flooding the street.  Suggest removing it to keep the humor consistent and reliable.  

For that matter, might be worth just shifting to only squirrels by removing:
* http://images.cheezburger.com/completestore/2011/11/2/aa83c0c4-2123-4bd3-8097-966c9461b30c.jpg
* http://i.imgur.com/DPVM1.png
