### PR TITLE
Fixed URL to bitbucket POST service instructions

### DIFF
--- a/src/scripts/bitbucket.coffee
+++ b/src/scripts/bitbucket.coffee
@@ -8,7 +8,7 @@
 # Configuration:
 #   For instructions on how to set up BitBucket's POST service for your
 #   repositories, visit:
-#   http://confluence.atlassian.com/display/BITBUCKET/Setting+Up+the+bitbucket+POST+Service
+#   https://confluence.atlassian.com/display/BITBUCKET/POST+hook+management
 #
 # Author:
 #   JRusbatch


### PR DESCRIPTION
The URL for the bitbucket instructions on creating a POST service led to a 404. I fixed the link to point to the correct page.