### PR TITLE
Remove experience as a trigger word - ive.coffee

### DIFF
--- a/src/scripts/ive.coffee
+++ b/src/scripts/ive.coffee
@@ -25,6 +25,6 @@ ives = [
 ]
 
 module.exports = (robot) ->
-  robot.hear /(aluminium|essential|elegant|efficient|experience|incredible|magical|meticulous|unibody|from the ground up)/i, (msg) ->
+  robot.hear /(aluminium|essential|elegant|efficient|incredible|magical|meticulous|unibody|from the ground up)/i, (msg) ->
     msg.send msg.random ives
 


### PR DESCRIPTION
"Experience" comes up too often outside of context of "user experience". 

"Does anyone have any experience with XXX tool" is annoying rather than fun. What do you think?