### PR TITLE
Improve robot hear regex of foaas

### DIFF
--- a/src/scripts/foass.coffee
+++ b/src/scripts/foass.coffee
@@ -13,7 +13,7 @@
 
 
 module.exports = (robot) ->
-  robot.hear /^fu ?(\w+)?/i, (msg) ->
+  robot.hear /^fu(?:\s)(?=([\w ]+))/i, (msg) ->
     options = [
       'off',
       'you',


### PR DESCRIPTION
I've found that the FOAAS responds when I'm not expecting it to, when Hubot hears any word beginning with 'fu' like fun, future, etc. E.g. hearing

fun time at the bar last night, eh?

… would get a FOAAS response. I think the regex needs improving.

This patch alters it to listen for 'fu' either followed by nothing, or followed by -space- and something (which can now be any number of words, whereas previously it was just a single word).