### PR TITLE
Resolve reduce of empty array with no initial val

### DIFF
--- a/src/scripts/jira-issues.coffee
+++ b/src/scripts/jira-issues.coffee
@@ -39,7 +39,7 @@ module.exports = (robot) ->
     .get() (err, res, body) ->
       json = JSON.parse(body)
       jiraPrefixes = ( entry.key for entry in json )
-      reducedPrefixes = jiraPrefixes.reduce (x,y) -> x + "-|" + y
+      reducedPrefixes = jiraPrefixes.reduce ((x,y) -> x + "-|" + y), 0
       jiraPattern = "/\\b(" + reducedPrefixes + "-)(\\d+)\\b/g"
       ic = process.env.HUBOT_JIRA_IGNORECASE
       if ic == undefined || ic == "true"


### PR DESCRIPTION
In case that there are no projects in jira it will start displaying error bellow due to array being empty and no initial value for reduce.

[Mon Oct 05 2015 03:03:21 GMT-0400 (EDT)] ERROR TypeError: Reduce of empty array with no initial value
  at Array.reduce (native)
  at /usr/local/xxx/node_modules/hubot-scripts/src/scripts/jira-issues.coffee:42:7, <js>:27:38
  at IncomingMessage.<anonymous> (/usr/local/xxx/node_modules/hubot/node_modules/scoped-http-client/src/index.js:95:22)
  at IncomingMessage.emit (events.js:117:20)
  at _stream_readable.js:944:16
  at process._tickCallback (node.js:448:13)