### PR TITLE
Fix lookup for stocks on named exchanges

### DIFF
--- a/src/scripts/stock.coffee
+++ b/src/scripts/stock.coffee
@@ -17,9 +17,9 @@
 
 module.exports = (robot) ->
   robot.respond /stock (?:info|price|quote)?\s?(?:for|me)?\s?@?([A-Za-z0-9.-_]+)\s?(\d+\w+)?/i, (msg) ->
-    ticker = escape(msg.match[1])
+    ticker = escape(msg.match[1].replace /https?:\/\//, '')
     time = msg.match[2] || '1d'
-    msg.http('http://finance.google.com/finance/info?client=ig&q=' + ticker)
+    msg.http('http://finance.google.com/finance/info?client=ig&q=' + ticker.replace '.', ':')
       .get() (err, res, body) ->
         result = JSON.parse(body.replace(/\/\/ /, ''))
         msg.send "http://chart.finance.yahoo.com/z?s=#{ticker}&t=#{time}&q=l&l=on&z=l&a=v&p=s&lang=en-US&region=US#.png"


### PR DESCRIPTION
Use ':' in Google URL for suffixed stock (e.g. VOW.DE) but '.' in Yahoo URL.

Also, remove 'http/https' prefix from ticker if present. Slack is an example where 'VOW.DE' is currently passed down as 'HTTP://VOW.DE' (wrongly, in my opinion).