### PR TITLE
github-pulls: Nicer format of messages

### DIFF
--- a/src/scripts/github-pulls.coffee
+++ b/src/scripts/github-pulls.coffee
@@ -53,9 +53,16 @@ module.exports = (robot) ->
           summary = "I found #{filtered_result.length} open pull requests for #{repo}:"
 
         for pull in filtered_result
-          summary = summary + "\n\t#{pull.title} - #{pull.user.login}: #{pull.html_url}"
+          summary = summary + "\n\t\<#{pull.html_url}|##{pull.number}> - #{pull.title} (#{pull.user.login})"
 
-      msg.send summary
+      if process.env.HUBOT_SLACK_INCOMING_WEBHOOK?
+        robot.emit 'slack.attachment',
+          message: msg.message
+          content:
+            fallback: summary
+            text: summary
+      else
+        msg.send summary
 
   robot.respond /show\s+(me\s+)?org\-pulls(\s+for\s+)?(.*)?/i, (msg) ->
 


### PR DESCRIPTION
using `slack.attachment` so that we can have nice formatting with links and such.

<img width="580" alt="screen shot 2015-10-15 at 7 24 43 am" src="https://cloud.githubusercontent.com/assets/305268/10516879/33624854-730f-11e5-9889-dc44789307f3.png">
