### PR TITLE
print link to beer label if available

### DIFF
--- a/src/scripts/brewerydb.coffee
+++ b/src/scripts/brewerydb.coffee
@@ -46,3 +46,6 @@ module.exports = (robot) ->
           if beer['foodPairings']?
             response += "\nFood Pairings:   #{beer['foodPairings']}"
           msg.send response
+          if beer['labels']?
+            response = "#{beer['labels']['medium']}"
+            msg.send response


### PR DESCRIPTION
Print link to the medium sized beer label if available via brewerydb. I created it as a separate hubot message since HipChat will bury it if the description of the beer is too long and thus not automatically displaying the image.