### PR TITLE
Round darksky temperatures to 2 decimal places

### DIFF
--- a/src/scripts/darksky.coffee
+++ b/src/scripts/darksky.coffee
@@ -58,6 +58,8 @@ darkSkyMe = (msg, lat, lng, cb) ->
       else
         celsius = result.currently.temperature
         fahrenheit = celsius * (9 / 5) + 32
+      fahrenheit = fahrenheit.toFixed(2)
+      celsius = celsius.toFixed(2)
       response = "Currently: #{result.currently.summary} (#{fahrenheit}°F/"
       response += "#{celsius}°C). "
       response += "Today: #{result.hourly.summary} "


### PR DESCRIPTION
Currently if you have the darksky script set to Fahrenheit by default, you'll usually end up with an ugly Celsius temperature, like this:
> Currently: Light Rain (46.68°F/8.155555555555555°C)

This changes it to look like:
> Currently: Light Rain (46.68°F/8.16°C)