### PR TITLE
Release 2.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-scripts",
-  "version": "2.16.2",
+  "version": "2.17.0",
 
   "author": "hubot",
 


### PR DESCRIPTION
The only thing this includes is https://github.com/github/hubot-scripts/pull/1696 which starts to collect data about scripts that have package replacements.